### PR TITLE
Add configurable max rotor RPM and update usage

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/config/CKinetics.java
+++ b/src/main/java/org/patryk3211/powergrid/config/CKinetics.java
@@ -31,6 +31,8 @@ public class CKinetics extends ConfigBase {
 
     public final ConfigFloat motorRPMPerVolt = f(0.5f, 0, "motorRPMPerVolt", Comments.motorRPMPerVolt);
 
+    public final ConfigInt rotorRPMMax = i(256, 0, "rotorRPMMax", Comments.rotorRPMMax);
+
     public final CStress stressValues = nested(1, CStress::new, Comments.stress);
 
     @Override
@@ -46,7 +48,8 @@ public class CKinetics extends ConfigBase {
         public static final String lightningAttractorMaxFrequency = "How often can the lightning attractor fire";
         public static final String rotorAssemblyMaxSize = "Maximum length of a rotor assembly";
         public static final String motorRPMPerVolt = "Rotation speed of the electric motor for every volt across it";
-
+        public static final String rotorRPMMax = "Maximum rotation speed of a rotor";
+        
         public static final String stress = "Fine tune the kinetic stats of individual components";
     }
 }

--- a/src/main/java/org/patryk3211/powergrid/kinetics/generator/rotor/RotorBehaviour.java
+++ b/src/main/java/org/patryk3211/powergrid/kinetics/generator/rotor/RotorBehaviour.java
@@ -220,6 +220,10 @@ public class RotorBehaviour extends SegmentedBehaviour<RotorBehaviour> {
         return fieldStrength;
     }
 
+    public int getMaxRotationSpeed() {
+        return ModdedConfigs.server().kinetics.rotorRPMMax.get();
+    }
+
     public void setFieldStrength(float value) {
         fieldStrength = value;
         blockEntity.setChanged();
@@ -238,7 +242,7 @@ public class RotorBehaviour extends SegmentedBehaviour<RotorBehaviour> {
             if(Math.abs(angularVelocity) < 0.01 || Float.isNaN(angularVelocity))
                 angularVelocity = 0;
 
-            if(Math.abs(angularVelocity) > 320 && !getWorld().isClientSide) {
+            if(Math.abs(angularVelocity) > getMaxRotationSpeed() && !getWorld().isClientSide) {
                 // TODO: Maybe make this a bit more destructive.
                 getWorld().destroyBlock(getPos(), false);
             }

--- a/src/main/java/org/patryk3211/powergrid/kinetics/generator/rotor/RotorSoundInstance.java
+++ b/src/main/java/org/patryk3211/powergrid/kinetics/generator/rotor/RotorSoundInstance.java
@@ -72,7 +72,7 @@ public class RotorSoundInstance extends AbstractTickableSoundInstance {
             }
 
             var velocity = Math.abs(behaviour.getAngularVelocity());
-            var pitch = velocity / 128f;
+            var pitch = velocity / (behaviour.getMaxRotationSpeed() / 2f);
             if(velocity < 32) {
                 this.volume = 0.0f;
                 stop();
@@ -80,7 +80,7 @@ public class RotorSoundInstance extends AbstractTickableSoundInstance {
                 var volume = (velocity / 128);
                 this.volume = Mth.clamp(volume, 0, 1) * 0.3f;
             }
-            this.pitch = Mth.clamp(pitch, 0.5f, 2.0f);
+            this.pitch = Mth.clamp(pitch, 0.5f, 2f);
         }
     }
 }


### PR DESCRIPTION
Introduces a new rotorRPMMax configuration option to allow setting the maximum rotation speed of rotors. Updates RotorBehaviour to use this configurable value instead of a hardcoded limit, and adjusts RotorSoundInstance pitch calculation to scale with the new max RPM.

Implemented #148 