### PR TITLE
Fix incorrect UV mapping on relay.json

### DIFF
--- a/src/main/resources/assets/powergrid/models/component/relay.json
+++ b/src/main/resources/assets/powergrid/models/component/relay.json
@@ -11,7 +11,7 @@
 			"to": [4, 4, 3],
 			"faces": {
 				"north": {"uv": [0, 0, 4, 4], "texture": "#0"},
-				"east": {"uv": [5, 0, 8, 4], "texture": "#0"},
+				"east": {"uv": [4, 0, 7, 4], "texture": "#0"},
 				"south": {"uv": [0, 0, 4, 4], "texture": "#0"},
 				"west": {"uv": [4, 0, 7, 4], "texture": "#0"},
 				"up": {"uv": [0, 4, 4, 7], "texture": "#0"}


### PR DESCRIPTION
The Relay component has its UV mapping incorrectly offset by 1. So I fixed it-

<img width="2559" height="1388" alt="Screenshot 2025-09-16 081009" src="https://github.com/user-attachments/assets/cb056fe8-7fa4-4d0d-b1c7-55ea919d7660" />