### PR TITLE
Fix RPM of motor being multiplied by 1.2

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/kinetics/motor/ConstantSpeedMotorBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/kinetics/motor/ConstantSpeedMotorBlockEntity.java
@@ -56,7 +56,7 @@ public class ConstantSpeedMotorBlockEntity extends GeneratingKineticBlockEntity 
 
     public ConstantSpeedMotorBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
-        setLazyTickRate(AVERAGING_TICKS);
+        setLazyTickRate(AVERAGING_TICKS - 1);
     }
 
     public float torque() {

--- a/src/main/java/org/patryk3211/powergrid/kinetics/motor/ElectricMotorBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/kinetics/motor/ElectricMotorBlockEntity.java
@@ -48,7 +48,7 @@ public class ElectricMotorBlockEntity extends GeneratingKineticBlockEntity imple
 
     public ElectricMotorBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
-        setLazyTickRate(AVERAGING_TICKS);
+        setLazyTickRate(AVERAGING_TICKS - 1);
     }
 
     public float torque() {


### PR DESCRIPTION
Speed of 6 ticks is accumulated when the lazy tick rate is 5, resulting in the final speed being multiplied by 1.2