### PR TITLE
Fix HV Switch wrench pickup for extended part

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/electricity/electricswitch/HvSwitchBlock.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/electricswitch/HvSwitchBlock.java
@@ -232,12 +232,13 @@ public class HvSwitchBlock extends HorizontalKineticBlock implements IElectric, 
                 world.destroyBlock(pos.relative(facing), false);
             } else {
                 var pos2 = pos.relative(facing.getOpposite());
+                var state2 = world.getBlockState(pos2);
                 var player = context.getPlayer();
                 if(player != null && !player.isCreative()) {
-                    Block.getDrops(state, serverWorld, pos2, world.getBlockEntity(pos2), player, context.getItemInHand())
+                    Block.getDrops(state2, serverWorld, pos2, world.getBlockEntity(pos2), player, context.getItemInHand())
                             .forEach(stack -> player.getInventory().placeItemBackInInventory(stack));
                 }
-                state.spawnAfterBreak(serverWorld, pos2, ItemStack.EMPTY, true);
+                state2.spawnAfterBreak(serverWorld, pos2, ItemStack.EMPTY, true);
                 world.destroyBlock(pos2, false);
             }
         }


### PR DESCRIPTION
Fixes #477

When using a wrench on the extended part of the HV Switch block, the wrench pickup was breaking the block without returning the item to the player's inventory.

The issue was that the code was using the block state from the main block position instead of the extended part's position when calculating drops and handling the block break. This change ensures we fetch and use the correct block state () for the extended block at , so items are properly dropped and the wrench interaction works consistently across both parts of the block.