### PR TITLE
Fix 2x2 transformer assembly with explicit block updates

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/electricity/transformer/TransformerCoreBlock.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/transformer/TransformerCoreBlock.java
@@ -53,10 +53,10 @@ public class TransformerCoreBlock extends Block implements IWrenchable {
                     if(!world.isClientSide) {
                         var state = ModdedBlocks.TRANSFORMER_MEDIUM.getDefaultState()
                                 .setValue(TransformerMediumBlock.HORIZONTAL_AXIS, dir.getAxis());
-                        world.setBlockAndUpdate(pos.relative(dir, x).relative(Direction.UP, y), state.setValue(PART, 0));
-                        world.setBlockAndUpdate(pos.relative(dir, x + 1).relative(Direction.UP, y), state.setValue(PART, 1));
-                        world.setBlockAndUpdate(pos.relative(dir, x).relative(Direction.UP, y + 1), state.setValue(PART, 2));
-                        world.setBlockAndUpdate(pos.relative(dir, x + 1).relative(Direction.UP, y + 1), state.setValue(PART, 3));
+                        world.setBlock(pos.relative(dir, x).relative(Direction.UP, y), state.setValue(PART, 0), Block.UPDATE_CLIENTS);
+                        world.setBlock(pos.relative(dir, x + 1).relative(Direction.UP, y), state.setValue(PART, 1), Block.UPDATE_CLIENTS);
+                        world.setBlock(pos.relative(dir, x).relative(Direction.UP, y + 1), state.setValue(PART, 2), Block.UPDATE_CLIENTS);
+                        world.setBlock(pos.relative(dir, x + 1).relative(Direction.UP, y + 1), state.setValue(PART, 3), Block.UPDATE_ALL);
                     }
                     return true;
                 }


### PR DESCRIPTION
Replace setBlockAndUpdate with setBlock and explicit update flags for the transformer core assembly. The automatic updates weren't working correctly for assembling the 2x2 structure — using explicit UPDATE_CLIENTS and UPDATE_ALL flags fixes it.

Closes #492