### PR TITLE
fixed linux native build (needed -fPIC)

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -11,6 +11,8 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 set(SOURCES
     src/powergridNative/cpp/dense.cpp
     src/powergridNative/cpp/operations.cpp


### PR DESCRIPTION
The native part refused to build on my Linux machine due to a linker error. Position independent compilation (-fPIC) must be enabled.