### PR TITLE
Neoforge 1.21.1 Punchcard and dependency fixes

### DIFF
--- a/forge/src/main/java/org/patryk3211/powergrid/forge/PowerGridImpl.java
+++ b/forge/src/main/java/org/patryk3211/powergrid/forge/PowerGridImpl.java
@@ -44,6 +44,8 @@ import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.fml.event.lifecycle.InterModEnqueueEvent;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
@@ -188,6 +190,12 @@ public class PowerGridImpl {
         forbiddenBlockEntities.stream()
                 .map(entry -> entry.getId().toString())
                 .forEach(id -> InterModComms.sendTo("carryon", "blacklistBlock", () -> id));
+    }
+
+    @SubscribeEvent
+    public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+        event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, ModdedBlockEntities.PUNCH_CARD_READER.get(),
+                (be, side) -> ((PunchCardReaderBlockEntityImpl) be).getItemHandler(side));
     }
 
     @SubscribeEvent

--- a/forge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/forge/src/main/resources/META-INF/neoforge.mods.toml
@@ -15,35 +15,35 @@ logoFile = "assets/powergrid/icon.png"
 
 [[dependencies.powergrid]]
 modId = "neoforge"
-mandatory = true
+type = "required"
 versionRange = "${neoforge_version_range}"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.powergrid]]
 modId = "minecraft"
-mandatory = true
+type = "required"
 versionRange = "[${minecraft_version},)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.powergrid]]
 modId = "architectury"
-mandatory = true
+type = "required"
 versionRange = "[${architectury_version},)"
 ordering = "AFTER"
 side = "BOTH"
 
 [[dependencies.powergrid]]
 modId = "create"
-mandatory = true
+type = "required"
 versionRange = "${create_forge_version}"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.powergrid]]
 modId = "tfmg"
-mandatory = false
+type = "optional"
 versionRange = "${tfmg_forge_range}"
 ordering = "NONE"
 side = "BOTH"

--- a/src/main/java/org/patryk3211/powergrid/kinetics/punchcard/PunchCardReaderBlock.java
+++ b/src/main/java/org/patryk3211/powergrid/kinetics/punchcard/PunchCardReaderBlock.java
@@ -128,7 +128,7 @@ public class PunchCardReaderBlock extends ElectricKineticBlock implements IBE<Pu
     protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
         return onBlockEntityUseItemOn(level, pos, be -> {
             var side = hit.getDirection();
-            if(side != Direction.UP && side != state.getValue(HORIZONTAL_FACING))
+            if(side != Direction.UP && side != state.getValue(HORIZONTAL_FACING) || stack.isEmpty())
                 return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
             if(stack.getItem() instanceof PunchCardItem) {
                 if(be.insertCard(stack, side)) {


### PR DESCRIPTION
Fixes both hand and inventory interactions for the Punchcard Reader on Neoforge. Currently, you are unable to remove a punch card from the reader with an empty hand because the `useItemOn` method does not allow the interaction to pass to the `useWithoutItem` method. Also, the `IItemHandler` for the reader was not exposed to Neoforge so items could not be inserted or extracted using hoppers, chutes, etc. This pull request should fix both of these issues.

I also fixed the Neoforge dependency requirements since `mandatory` has been replaced with `type`. Without this, I couldn't run without tfmg.