### PR TITLE
Cache CircuitBoardBlockEntity shapes by orientation

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlock.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlock.java
@@ -109,7 +109,7 @@ public class CircuitBoardBlock extends ElectricBlock implements IBE<CircuitBoard
         super.setPlacedBy(world, pos, state, placer, stack);
     }
 
-    private static VoxelShape rotate(VoxelShape shapeIn, float x, float y) {
+    public static VoxelShape rotate(VoxelShape shapeIn, float x, float y) {
         if(y == 0 && x == 0)
             return shapeIn;
 
@@ -164,20 +164,14 @@ public class CircuitBoardBlock extends ElectricBlock implements IBE<CircuitBoard
 
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext context) {
-        int x = getAngleX(state), y = getAngleY(state);
-        final var shape = new VoxelShape[] { rotate(SHAPE_PLATE, x, y) };
+        int x = getAngleX(state);
+        int y = getAngleY(state);
+        final VoxelShape[] shape = {rotate(SHAPE_PLATE, x, y)};
+
         withBlockEntityDo(world, pos, be -> {
-            var shapeCopy = shape[0];
-            for(int i = 0; i < be.terminalCount(); i++) {
-                var terminal = be.terminal(state, i);
-                shapeCopy = Shapes.or(((TerminalBoundingBox) terminal).getShape(), shapeCopy);
-            }
-            for(var placed : be.getComponents(IInteractableComponent.class)) {
-                var dynamic = (IInteractableComponent) placed.component;
-                shapeCopy = Shapes.or(rotate(dynamic.getShape(placed), x, y), shapeCopy);
-            }
-            shape[0] = shapeCopy;
+            shape[0] = be.getShape(state, shape[0]);
         });
+
         return shape[0];
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
@@ -20,7 +20,6 @@ import com.simibubi.create.content.kinetics.fan.AirCurrent;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import dev.architectury.utils.Env;
 import dev.architectury.utils.EnvExecutor;
-import net.createmod.catnip.data.Pair;
 import net.createmod.catnip.math.VecHelper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -76,8 +75,9 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
     @Environment(EnvType.CLIENT)
     public CircuitBoardModelQuads quads;
 
-    @NotNull
-    private final HashMap<Pair<Integer, Integer>, VoxelShape> shapeCache = new HashMap<>();
+    private VoxelShape shapeCache = null;
+    private int angleXCache = 0;
+    private int angleYCache = 0;
     private int terminalCountCache = 0;
     private int interactableCountCache = 0;
 
@@ -86,8 +86,8 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
     }
 
     /**
-     * Get the shape of this circuit board. Shapes will be fetched from cache if this board has been in the provided
-     * orientation before and components have not changed since.
+     * Get the shape of this circuit board. Shapes will be fetched from cache if the board orientation and components
+     * have not changed since the last getShape call.
      * @param state a BlockState containing the orientation of this circuit board
      * @param baseShape the base VoxelShape to build upon
      * @return the VoxelShape of the board in the provided orientation
@@ -95,19 +95,14 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
     public VoxelShape getShape(BlockState state, VoxelShape baseShape) {
         int x = CircuitBoardBlock.getAngleX(state);
         int y = CircuitBoardBlock.getAngleY(state);
-        var angles = Pair.of(x, y);
         VoxelShape newShape = baseShape;
 
         int terminalCount = terminalCount();
         int interactableCount = getComponents(IInteractableComponent.class).size();
 
-        // Recompute all shapes if shaped components have changed
-        if (terminalCountCache != terminalCount || interactableCountCache != interactableCount) {
-            shapeCache.clear();
-        }
-
-        if (!shapeCache.containsKey(angles)) {
-            // Recompute only this orientation if it hasn't been cached already
+        // Recompute shape if shaped components or orientation have changed
+        if (shapeCache == null || angleXCache != x || angleYCache != y ||
+                terminalCountCache != terminalCount || interactableCountCache != interactableCount) {
             for (int i = 0; i < terminalCount; i++) {
                 var terminal = terminal(state, i);
                 newShape = Shapes.or(((TerminalBoundingBox) terminal).getShape(), newShape);
@@ -116,12 +111,14 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
                 var dynamic = (IInteractableComponent) placed.component;
                 newShape = Shapes.or(CircuitBoardBlock.rotate(dynamic.getShape(placed), x, y), newShape);
             }
-            shapeCache.put(angles, newShape);
+            shapeCache = newShape;
+            angleXCache = x;
+            angleYCache = y;
             terminalCountCache = terminalCount;
             interactableCountCache = interactableCount;
         }
         else {
-            newShape = shapeCache.get(angles);
+            newShape = shapeCache;
         }
 
         return newShape;

--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
@@ -20,6 +20,7 @@ import com.simibubi.create.content.kinetics.fan.AirCurrent;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import dev.architectury.utils.Env;
 import dev.architectury.utils.EnvExecutor;
+import net.createmod.catnip.data.Pair;
 import net.createmod.catnip.math.VecHelper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -31,11 +32,14 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.patryk3211.powergrid.circuits.components.Component;
 import org.patryk3211.powergrid.circuits.components.IComponentGoggleInformation;
+import org.patryk3211.powergrid.circuits.components.IInteractableComponent;
 import org.patryk3211.powergrid.circuits.components.ViaComponent;
 import org.patryk3211.powergrid.circuits.components.properties.Orientation;
 import org.patryk3211.powergrid.circuits.schematic.CircuitSchematic;
@@ -44,10 +48,7 @@ import org.patryk3211.powergrid.circuits.schematic.PlacedComponent;
 import org.patryk3211.powergrid.collections.ModdedBlockEntities;
 import org.patryk3211.powergrid.collections.ModdedPackets;
 import org.patryk3211.powergrid.electricity.GlobalElectricNetworks;
-import org.patryk3211.powergrid.electricity.base.ElectricBehaviour;
-import org.patryk3211.powergrid.electricity.base.ElectricBlockEntity;
-import org.patryk3211.powergrid.electricity.base.IElectric;
-import org.patryk3211.powergrid.electricity.base.ITerminalPlacement;
+import org.patryk3211.powergrid.electricity.base.*;
 import org.patryk3211.powergrid.electricity.sim.ElectricWire;
 import org.patryk3211.powergrid.electricity.sim.ElectricalNetwork;
 import org.patryk3211.powergrid.electricity.sim.node.FloatingNode;
@@ -75,8 +76,55 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
     @Environment(EnvType.CLIENT)
     public CircuitBoardModelQuads quads;
 
+    @NotNull
+    private final HashMap<Pair<Integer, Integer>, VoxelShape> shapeCache = new HashMap<>();
+    private int terminalCountCache = 0;
+    private int interactableCountCache = 0;
+
     public CircuitBoardBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
+    }
+
+    /**
+     * Get the shape of this circuit board. Shapes will be fetched from cache if this board has been in the provided
+     * orientation before and components have not changed since.
+     * @param state a BlockState containing the orientation of this circuit board
+     * @param baseShape the base VoxelShape to build upon
+     * @return the VoxelShape of the board in the provided orientation
+     */
+    public VoxelShape getShape(BlockState state, VoxelShape baseShape) {
+        int x = CircuitBoardBlock.getAngleX(state);
+        int y = CircuitBoardBlock.getAngleY(state);
+        var angles = Pair.of(x, y);
+        VoxelShape newShape = baseShape;
+
+        int terminalCount = terminalCount();
+        int interactableCount = getComponents(IInteractableComponent.class).size();
+
+        // Recompute all shapes if shaped components have changed
+        if (terminalCountCache != terminalCount || interactableCountCache != interactableCount) {
+            shapeCache.clear();
+        }
+
+        if (!shapeCache.containsKey(angles)) {
+            // Recompute only this orientation if it hasn't been cached already
+            for (int i = 0; i < terminalCount; i++) {
+                var terminal = terminal(state, i);
+                newShape = Shapes.or(((TerminalBoundingBox) terminal).getShape(), newShape);
+            }
+            for (var placed : getComponents(IInteractableComponent.class)) {
+                var dynamic = (IInteractableComponent) placed.component;
+                newShape = Shapes.or(CircuitBoardBlock.rotate(dynamic.getShape(placed), x, y), newShape);
+            }
+            shapeCache.put(angles, newShape);
+            terminalCountCache = terminalCount;
+            interactableCountCache = interactableCount;
+        }
+        else {
+            newShape = shapeCache.get(angles);
+        }
+
+        return newShape;
     }
 
     @Override


### PR DESCRIPTION
Resolves #501 by caching circuit board shape to avoid recomputing every tick during raycasts/collisions. Caches separately for different orientations to update shape after wrenching.