### PR TITLE
Fix for circuit design table background bug

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/circuits/gui/ComponentPropertiesWidget.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/gui/ComponentPropertiesWidget.java
@@ -144,7 +144,7 @@ public class ComponentPropertiesWidget extends AbstractSimiWidget {
         int centerSliceSize = Math.max(width - 120, 0);
         ctx.blit(PROPERTIES, 0, 0, 0, 0, 60, 16);
         if(width > 120) {
-            ctx.blitSprite(PROPERTIES, 60, 0, centerSliceSize, 16, 61, 0, 30, 16);
+            blitRepeating(ctx, PROPERTIES, 60, 0, centerSliceSize, 16, 61,0, 30, 16);
         }
         ctx.blit(PROPERTIES, 60 + centerSliceSize, 0, 92, 0, 60, 16);
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/gui/ComponentPropertiesWidget.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/gui/ComponentPropertiesWidget.java
@@ -144,7 +144,7 @@ public class ComponentPropertiesWidget extends AbstractSimiWidget {
         int centerSliceSize = Math.max(width - 120, 0);
         ctx.blit(PROPERTIES, 0, 0, 0, 0, 60, 16);
         if(width > 120) {
-            blitRepeating(ctx, PROPERTIES, 60, 0, centerSliceSize, 16, 61,0, 30, 16);
+            blitRepeating(ctx, PROPERTIES, 60, 0, centerSliceSize, 16, 61, 0, 30, 16);
         }
         ctx.blit(PROPERTIES, 60 + centerSliceSize, 0, 92, 0, 60, 16);
 


### PR DESCRIPTION
Simple fix for the background with long named components

<img width="363" height="77" alt="image" src="https://github.com/user-attachments/assets/29dc9336-5cde-4a9e-867d-8feea0b88678" />
