### PR TITLE
fix for multimeter in current mode never disconnecting cable because of range

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/equipment/multimeter/MultimeterItem.java
+++ b/src/main/java/org/patryk3211/powergrid/equipment/multimeter/MultimeterItem.java
@@ -166,7 +166,7 @@ public class MultimeterItem extends Item implements IHaveElectricProperties {
                                         .style(ChatFormatting.GRAY)
                                         .component(), true);
                             // Wipe all data
-                            saveModeData(stack, data);
+                            deleteModeData(stack);
                         }
                     }
                 }

--- a/src/main/java/org/patryk3211/powergrid/equipment/multimeter/MultimeterItem.java
+++ b/src/main/java/org/patryk3211/powergrid/equipment/multimeter/MultimeterItem.java
@@ -166,7 +166,6 @@ public class MultimeterItem extends Item implements IHaveElectricProperties {
                                         .style(ChatFormatting.GRAY)
                                         .component(), true);
                             // Wipe all data
-                            data.remove("ModeData");
                             saveModeData(stack, data);
                         }
                     }
@@ -179,13 +178,8 @@ public class MultimeterItem extends Item implements IHaveElectricProperties {
                                     .style(ChatFormatting.GRAY)
                                     .component(), true);
                         // Wipe all data
-                        data.remove("ModeData");
+                        deleteModeData(stack);
                     }
-                }
-                if (data.isEmpty()) {
-                        stack.remove(DataComponents.CUSTOM_DATA);
-                } else {
-                    saveModeData(stack, data);
                 }
             }
         }
@@ -232,6 +226,14 @@ public class MultimeterItem extends Item implements IHaveElectricProperties {
         }
 
         return modeData;
+    }
+
+    public static void deleteModeData(ItemStack stack) {
+        CompoundTag root = stack
+                .getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY)
+                .copyTag();
+        root.remove("ModeData");
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(root));
     }
 
     public static void saveModeData(ItemStack stack, CompoundTag modeData) {


### PR DESCRIPTION

https://github.com/user-attachments/assets/d08a4a6b-c0e2-4729-bedc-52d91e9a2407

bug in question

I also removed an if statement that saved the mode data every tick when the multimeter was in current mode because I couldn't see a reason that it was needed, but if there was a good reason for it and I didn't see it I will add it back.