### PR TITLE
Attempt to resolve memory leaks by releasing the buffer after using it

### DIFF
--- a/forge/src/main/java/org/patryk3211/powergrid/forge/PowerGridImpl.java
+++ b/forge/src/main/java/org/patryk3211/powergrid/forge/PowerGridImpl.java
@@ -160,8 +160,12 @@ public class PowerGridImpl {
                 CustomPayloadWrapper.type(packets.c2sPacket),
                 CustomPayloadWrapper.codec(packets.c2sPacket),
                 (payload, context) -> {
-                    if (context.player() instanceof ServerPlayer serverPlayer) {
-                        packets.handleC2SPacket(serverPlayer, payload.data());
+                    try {
+                        if (context.player() instanceof ServerPlayer serverPlayer) {
+                            packets.handleC2SPacket(serverPlayer, payload.data());
+                        }
+                    } finally {
+                        payload.release();
                     }
                 }
         );
@@ -169,8 +173,12 @@ public class PowerGridImpl {
                 CustomPayloadWrapper.type(packets.s2cPacket),
                 CustomPayloadWrapper.codec(packets.s2cPacket),
                 (payload, context) -> {
-                    var mc = net.minecraft.client.Minecraft.getInstance();
-                    packets.handleS2CPacket(mc, payload.data());
+                    try {
+                        var mc = net.minecraft.client.Minecraft.getInstance();
+                        packets.handleS2CPacket(mc, payload.data());
+                    } finally {
+                        payload.release();
+                    }
                 }
         );
     }

--- a/src/main/java/org/patryk3211/powergrid/network/CustomPayloadWrapper.java
+++ b/src/main/java/org/patryk3211/powergrid/network/CustomPayloadWrapper.java
@@ -20,6 +20,15 @@ public record CustomPayloadWrapper(Type<CustomPayloadWrapper> type, FriendlyByte
     }
 
     /**
+     * Call this when you are done with the payload data
+     */
+    public void release() {
+        if (data != null && data.refCnt() > 0) {
+            data.release();
+        }
+    }
+
+    /**
      * Returns a {@link StreamCodec} for serializing and deserializing {@link CustomPayloadWrapper} instances.
      * <p>
      * This method is intended to be used for registering the codec with Minecraft's networking system
@@ -38,9 +47,9 @@ public record CustomPayloadWrapper(Type<CustomPayloadWrapper> type, FriendlyByte
                     buf.writeBytes(payload.data, payload.data.readerIndex(), payload.data.readableBytes());
                 },
                 (buf) -> {
-                    // Read all available bytes into a new retained buffer slice
+                    // Read all available bytes into a new buffer
                     int readableBytes = buf.readableBytes();
-                    FriendlyByteBuf data = new FriendlyByteBuf(buf.readRetainedSlice(readableBytes));
+                    FriendlyByteBuf data = new FriendlyByteBuf(buf.readBytes(readableBytes).asReadOnly());
                     return new CustomPayloadWrapper(new Type<>(id), data);
                 }
         );


### PR DESCRIPTION
I noticed that whenever you decoded a packet, a buffer was written to a FriendlyByteBuf class. The problem with this is that after reading, it was never released, making a memory leak. What I also did in this PR was making the decoded buffer readonly, so it will throw an exception if it ever gets written to, which makes it safer. This should resolve #621 