### PR TITLE
Fix Grounding Rod death message bug

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/electricity/grounding/GroundingRodBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/grounding/GroundingRodBlockEntity.java
@@ -17,12 +17,15 @@ package org.patryk3211.powergrid.electricity.grounding;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
@@ -127,10 +130,31 @@ public class GroundingRodBlockEntity extends ElectricBlockEntity {
             var entities = level.getEntitiesOfClass(LivingEntity.class, bb, e -> e.position().distanceToSqr(center) <= sqrDist && e.onGround());
 
             Registry<DamageType> registry = level.registryAccess().registryOrThrow(Registries.DAMAGE_TYPE);
-            var source = new DamageSource(registry.getHolder(ModdedDamageTypes.ZAP).get());
+            var source = new GroundingRodDamageSource(registry.getHolder(ModdedDamageTypes.ZAP).get(), this.getBlockState().getBlock());
             for(var entity : entities) {
                 // TODO: Scale damage with potential.
                 entity.hurt(source, 1);
+            }
+        }
+    }
+
+    public static class GroundingRodDamageSource extends DamageSource {
+        private final Block rod;
+
+        public GroundingRodDamageSource(Holder<DamageType> type, Block rod) {
+            super(type);
+            this.rod = rod;
+        }
+
+        @Override
+        public Component getLocalizedDeathMessage(LivingEntity killed) {
+            var translationId = "death.attack." + this.type().msgId();
+            var primeAdversary = killed.getKillCredit();
+            var machineName = Component.translatable(rod.getDescriptionId());
+            if(primeAdversary != null) {
+                return Component.translatable(translationId + ".player", killed.getDisplayName(), machineName, primeAdversary.getDisplayName());
+            } else {
+                return Component.translatable(translationId, killed.getDisplayName(), machineName);
             }
         }
     }

--- a/src/main/resources/assets/powergrid/lang/default/messages.json
+++ b/src/main/resources/assets/powergrid/lang/default/messages.json
@@ -32,5 +32,6 @@
   "death.attack.overloaded_machine": "%s was killed by an overloaded %s",
   "death.attack.overloaded_machine.player": "%s was killed by an overloaded %s whilst trying to escape %s",
   "death.attack.zap": "%1$s was zapped by %2$s",
-  "death.attack.zap.item": "%1$s was zapped by %2$s using %3$s"
+  "death.attack.zap.item": "%1$s was zapped by %2$s using %3$s",
+  "death.attack.zap.player": "%1$s was zapped by %2$s whilst trying to escape %3$s"
 }


### PR DESCRIPTION
Fix for #571

Needs to be pulled to 1.21.1 as well.

Fixed by using the same code that the overloaded machine kill message uses and also added the message for when a player is killed by the grounding rod while escaping another player