### PR TITLE
Fix TPS circuit board performance issue

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/CircuitBoardEndpoint.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/CircuitBoardEndpoint.java
@@ -18,6 +18,7 @@ package org.patryk3211.powergrid.electricity.wire;
 import net.createmod.catnip.math.VecHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.SectionPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
@@ -97,6 +98,8 @@ public class CircuitBoardEndpoint implements IWireEndpoint {
     }
 
     public ElectricBehaviour getElectricBehaviour(Level world) {
+        if(!world.hasChunk(SectionPos.blockToSectionCoord(pos.getX()), SectionPos.blockToSectionCoord(pos.getZ())))
+            return null;
         return world.getBlockEntity(pos, ModdedBlockEntities.CIRCUIT_BOARD.get())
                 .map(ElectricBlockEntity::getElectricBehaviour)
                 .orElse(null);


### PR DESCRIPTION
Hi there,

We've been playing with the mod a little bit on our server and noticed TPS getting particularly bad with many players online. I had a little look using spark and then noticed that the circuit board endpoint getElectricBehaviour doesn't check if the chunk is loaded before accessing like all the other endpoints. I added the check seen in this commit and it fixed the performance issues for our server.

Thanks,
Jensen