### PR TITLE
Add battery capacity config option

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/config/CElectricity.java
+++ b/src/main/java/org/patryk3211/powergrid/config/CElectricity.java
@@ -36,6 +36,7 @@ public class CElectricity extends ConfigBase {
     public final ConfigInt portableBatteryBaseCapacity = i(10000, 1, "portableBatteryBaseCapacity", Comments.portableBatteryBaseCapacity);
     public final ConfigInt portableBatteryEnchantCapacity = i(10000, 1, "portableBatteryEnchantCapacity", Comments.portableBatteryEnchantCapacity);
 
+    public final ConfigFloat acidBatteryCapacity = f(720f, 0, "acidBatteryCapacity", Comments.acidBatteryCapacity);
     public final ConfigFloat acidBatteryInitialCharge = f(0.9f, 0, 1.0f, "acidBatteryInitialCharge", Comments.acidBatteryInitialCharge);
 
     public final ConfigFloat transformerMutualInductanceMultiplier = f(10, 1, "transformerMutualInductanceMultiplier", Comments.transformerMutualInductanceMultiplier);
@@ -95,6 +96,7 @@ public class CElectricity extends ConfigBase {
         public static final String portableBatteryEnchantCapacity = "Portable Battery Forge Energy capacity increase per level of Capacity enchant";
 
         public static final String acidBatteryInitialCharge = "Initial charge of the acid battery";
+        public static final String acidBatteryCapacity = "Capacity of the acid battery, measured in joules";
 
         public static final String transformerMutualInductanceMultiplier = "Multiplies the mutual inductance of transformers to get a resistance. Bigger values make transformers use less electricity.";
 

--- a/src/main/java/org/patryk3211/powergrid/electricity/battery/SimpleBatterySpec.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/battery/SimpleBatterySpec.java
@@ -22,26 +22,26 @@ import java.util.function.Supplier;
 
 public class SimpleBatterySpec implements BatterySpec {
     public static final SimpleBatterySpec ACID_BATTERY = new SimpleBatterySpec(
-            7200, // This should amount to 1A for 1 minute at 12V
-            () -> 7200 * ModdedConfigs.server().electricity.acidBatteryInitialCharge.getF(),
+            () -> ModdedConfigs.server().electricity.acidBatteryCapacity.getF() * 10,
+            () -> ModdedConfigs.server().electricity.acidBatteryCapacity.getF() * 10 * ModdedConfigs.server().electricity.acidBatteryInitialCharge.getF(),
             e -> 1.2f * e + 11.5f,
             // This resistance makes the battery effectively dead after a deep discharge
             e -> Math.min(10000, (float) Math.exp(-21.18323 * e + 10.58157) + 0.1f)
     );
 
-    private final float maxCharge;
+    private final Supplier<Float> maxCharge;
     private final Supplier<Float> initialCharge;
     private final Function<Float, Float> voltageFunction;
     private final Function<Float, Float> resistanceFunction;
 
     public SimpleBatterySpec(float maxCharge, float initialCharge, Function<Float, Float> voltageFunction, Function<Float, Float> resistanceFunction) {
-        this.maxCharge = maxCharge;
+        this.maxCharge = () -> maxCharge;
         this.initialCharge = () -> initialCharge;
         this.voltageFunction = voltageFunction;
         this.resistanceFunction = resistanceFunction;
     }
 
-    public SimpleBatterySpec(float maxCharge, Supplier<Float> initialCharge, Function<Float, Float> voltageFunction, Function<Float, Float> resistanceFunction) {
+    public SimpleBatterySpec(Supplier<Float> maxCharge, Supplier<Float> initialCharge, Function<Float, Float> voltageFunction, Function<Float, Float> resistanceFunction) {
         this.maxCharge = maxCharge;
         this.initialCharge = initialCharge;
         this.voltageFunction = voltageFunction;
@@ -50,7 +50,7 @@ public class SimpleBatterySpec implements BatterySpec {
 
     @Override
     public float getMaxCharge() {
-        return maxCharge;
+        return maxCharge.get();
     }
 
     @Override


### PR DESCRIPTION
Hi, I've noticed that battery blocks are surprisingly weak as for their size and there is no way for player to modify their capacity, so I've made this PR.

Btw why are they so weak by default? For my own world, I've roughly (and to very low end) calculated capacity of 1m^3 lead acid battery so it has 1500Ah capacity. Or 1500*3600 joules.