### PR TITLE
Replace instanceof with BlockEntityBehaviour.get

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/electricity/base/ElectricBehaviour.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/base/ElectricBehaviour.java
@@ -391,22 +391,18 @@ public class ElectricBehaviour extends BlockEntityBehaviour implements ISynchron
             // Block entities no longer ticking.
             // Above level 33 the entities get completely unloaded so no need to pause them.
             for(var be : chunk.getBlockEntities().values()) {
-                if(be instanceof SmartBlockEntity smart) {
-                    var electric = smart.getBehaviour(ElectricBehaviour.TYPE);
-                    if(electric == null)
-                        continue;
-                    electric.pause();
-                }
+                var electric = BlockEntityBehaviour.get(be, ElectricBehaviour.TYPE);
+                if(electric == null)
+                    continue;
+                electric.pause();
             }
         } else if(ChunkLevel.isBlockTicking(newLevel)) {
             // Block entities ticking again.
             for(var be : chunk.getBlockEntities().values()) {
-                if(be instanceof SmartBlockEntity smart) {
-                    var electric = smart.getBehaviour(ElectricBehaviour.TYPE);
-                    if(electric == null)
-                        continue;
-                    electric.unpause();
-                }
+                var electric = BlockEntityBehaviour.get(be, ElectricBehaviour.TYPE);
+                if(electric == null)
+                    continue;
+                electric.unpause();
             }
         }
     }

--- a/src/main/java/org/patryk3211/powergrid/electricity/base/IElectric.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/base/IElectric.java
@@ -17,6 +17,7 @@ package org.patryk3211.powergrid.electricity.base;
 
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
+import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
@@ -114,10 +115,7 @@ public interface IElectric extends IWrenchable {
 
     @Nullable
     default ElectricBehaviour getBehaviour(Level world, BlockPos pos, BlockState state) {
-        var blockEntity = world.getBlockEntity(pos);
-        if(blockEntity instanceof SmartBlockEntity smartEntity)
-            return smartEntity.getBehaviour(ElectricBehaviour.TYPE);
-        return null;
+        return BlockEntityBehaviour.get(world, pos, ElectricBehaviour.TYPE);
     }
 
     @Nullable

--- a/src/main/java/org/patryk3211/powergrid/electricity/base/IElectric.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/base/IElectric.java
@@ -16,7 +16,6 @@
 package org.patryk3211.powergrid.electricity.base;
 
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
-import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;

--- a/src/main/java/org/patryk3211/powergrid/ponder/PowerGridPonderPlugin.java
+++ b/src/main/java/org/patryk3211/powergrid/ponder/PowerGridPonderPlugin.java
@@ -16,6 +16,7 @@
 package org.patryk3211.powergrid.ponder;
 
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
+import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import net.createmod.ponder.api.level.PonderLevel;
 import net.createmod.ponder.api.registration.PonderPlugin;
 import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
@@ -51,11 +52,9 @@ public class PowerGridPonderPlugin implements PonderPlugin {
     @Override
     public void onPonderLevelRestore(PonderLevel ponderLevel) {
         for(var be : ponderLevel.getBlockEntities()) {
-            if(be instanceof SmartBlockEntity smart) {
-                var electric = smart.getBehaviour(ElectricBehaviour.TYPE);
-                if(electric != null)
-                    electric.unpause();
-            }
+            var electric = BlockEntityBehaviour.get(be, ElectricBehaviour.TYPE);
+            if(electric != null)
+                electric.unpause();
         }
     }
 }

--- a/src/main/java/org/patryk3211/powergrid/ponder/PowerGridPonderPlugin.java
+++ b/src/main/java/org/patryk3211/powergrid/ponder/PowerGridPonderPlugin.java
@@ -15,7 +15,6 @@
  */
 package org.patryk3211.powergrid.ponder;
 
-import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import net.createmod.ponder.api.level.PonderLevel;
 import net.createmod.ponder.api.registration.PonderPlugin;


### PR DESCRIPTION
As talked about in discord, replaces `instanceof  SmartBlockEntity` and `getBehaviour `with `BlockEntityBehaviour.get`.
Useful for my mixining, and slightly cleaner code (9 lines less!).