### PR TITLE
Fixed Portable Batteries Breaking

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/collections/ModdedItems.java
+++ b/src/main/java/org/patryk3211/powergrid/collections/ModdedItems.java
@@ -218,7 +218,7 @@ public class ModdedItems {
                     p -> SubstituteItemProvider.INSTANCE.invoke(PortableBatteryItem.class, ZincArmorMaterial.INSTANCE, p, PowerGrid.asResource("zinc"), PORTABLE_BATTERY_PLACEABLE))
             //p -> new PortableBatteryItem(ZincArmorMaterial.INSTANCE, p, PowerGrid.asResource("zinc"), PORTABLE_BATTERY_PLACEABLE))
             .model(itemWithParent("block/portable_battery/block"))
-            .properties(p -> p.durability(-1))
+            // .properties(p -> p.durability(-1))
 			.tag(forgeItemTag("chestplates"))
             .register();
 


### PR DESCRIPTION
Fixed portable batteries breaking from any damage in 1.21.1. Fixed by just not setting the durability.
If properties is still meant to be there even if it isn't specifying the durability, MB, I don't know how to mod.