### PR TITLE
PCB Fuse tweaks

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/circuits/components/FuseHolderComponent.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/FuseHolderComponent.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 public class FuseHolderComponent extends OrientableComponent implements IInteractableComponent, IGoggleLabel {
     public static final EnumProperty<FuseState> STATE = new EnumProperty<>(PowerGrid.MOD_ID, "fuse_state", FuseState.class).hidden().cast();
-    public static final FloatProperty MAX_CURRENT = new FloatProperty(PowerGrid.MOD_ID, "max_current", 10, 1, 20);
+    public static final FloatProperty MAX_CURRENT = new FloatProperty(PowerGrid.MOD_ID, "current_fuse_max", 10, 1, 20);
 
     public FuseHolderComponent(ComponentFootprint footprint) {
         super(footprint);
@@ -35,8 +35,7 @@ public class FuseHolderComponent extends OrientableComponent implements IInterac
     @Override
     protected void addProperties(ImmutableCollection.Builder<ComponentProperty<?>> properties) {
         super.addProperties(properties);
-        properties.add(STATE);
-        properties.add(MAX_CURRENT);
+        properties.add(STATE, MAX_CURRENT);
     }
 
     @Override

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/FuseHolderComponent.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/FuseHolderComponent.java
@@ -1,6 +1,7 @@
 package org.patryk3211.powergrid.circuits.components;
 
 import com.google.common.collect.ImmutableCollection;
+import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -19,6 +20,7 @@ import org.patryk3211.powergrid.circuits.thermal.ThermalBuilder;
 import org.patryk3211.powergrid.collections.ModdedSoundEvents;
 import org.patryk3211.powergrid.collections.ModdedTags;
 import org.patryk3211.powergrid.electricity.fuse.FuseState;
+import org.patryk3211.powergrid.electricity.particles.SparkParticleData;
 import org.patryk3211.powergrid.electricity.sim.special.FuseSwitchWire;
 
 import java.util.Collection;
@@ -26,6 +28,7 @@ import java.util.List;
 
 public class FuseHolderComponent extends OrientableComponent implements IInteractableComponent, IGoggleLabel {
     public static final EnumProperty<FuseState> STATE = new EnumProperty<>(PowerGrid.MOD_ID, "fuse_state", FuseState.class).hidden().cast();
+    public static final EnumProperty<FuseState> PREV_STATE = new EnumProperty<>(PowerGrid.MOD_ID, "fuse_state_prev", FuseState.class).hidden().cast();
     public static final FloatProperty MAX_CURRENT = new FloatProperty(PowerGrid.MOD_ID, "current_fuse_max", 10, 1, 20);
 
     public FuseHolderComponent(ComponentFootprint footprint) {
@@ -35,7 +38,7 @@ public class FuseHolderComponent extends OrientableComponent implements IInterac
     @Override
     protected void addProperties(ImmutableCollection.Builder<ComponentProperty<?>> properties) {
         super.addProperties(properties);
-        properties.add(STATE, MAX_CURRENT);
+        properties.add(STATE, PREV_STATE, MAX_CURRENT);
     }
 
     @Override
@@ -52,18 +55,14 @@ public class FuseHolderComponent extends OrientableComponent implements IInterac
 
     @Override
     public boolean tick(@NotNull PlacedComponent placed) {
-        if(placed.wires.isEmpty())
+        if(placed.wires.isEmpty() || placed.isClient())
             return true;
 
         var fuseWire = (FuseSwitchWire) placed.wires.get(0);
         if (fuseWire.wasBlown()) {
             placed.set(STATE, FuseState.BLOWN);
-            placed.onServerWorld(() -> world -> {
-                var pos = placed.getPos();
-                ModdedSoundEvents.FUSE_POPS.playOnServer(world, pos, 1.0f, 1.0f);
-                placed.notifyClients(STATE);
-                stateUpdated(placed);
-            });
+            placed.notifyClients(STATE);
+            stateUpdated(placed);
         }
 
         return true;
@@ -75,7 +74,16 @@ public class FuseHolderComponent extends OrientableComponent implements IInterac
         if (placed.wires.isEmpty())
             return;
         ((FuseSwitchWire) placed.wires.get(0)).setState(placed.get(STATE) == FuseState.CLOSED);
-        placed.onClientWorld(() -> world -> modelChanged(placed.getPos()));
+        placed.onClientWorld(() -> world -> {
+            modelChanged(placed.getPos());
+            if (placed.get(STATE) == FuseState.BLOWN && placed.get(PREV_STATE) == FuseState.CLOSED) {
+                var pos = placed.getPos();
+                ModdedSoundEvents.FUSE_POPS.playAt(world, pos, 1.0f, 1.0f, false);
+                var localPos = placed.getExactPos();
+                SparkParticleData.explodeParticles(world, localPos.x, localPos.y, localPos.z, Direction.UP, 5);
+            }
+        });
+        placed.set(PREV_STATE, placed.get(STATE));
     }
 
     public boolean resetFuse(PlacedComponent placed) {

--- a/src/main/java/org/patryk3211/powergrid/circuits/schematic/PlacedComponent.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/schematic/PlacedComponent.java
@@ -15,10 +15,15 @@
  */
 package org.patryk3211.powergrid.circuits.schematic;
 
+import net.createmod.catnip.math.VecHelper;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
+import org.patryk3211.powergrid.circuits.circuitboard.CircuitBoardBlock;
 import org.patryk3211.powergrid.circuits.circuitboard.CircuitBoardBlockEntity;
 import org.patryk3211.powergrid.circuits.components.Component;
 import org.patryk3211.powergrid.circuits.components.ComponentRegistry;
@@ -262,6 +267,14 @@ public class PlacedComponent {
 
     public BlockPos getPos() {
         return pos;
+    }
+
+    public @NotNull Vec3 getExactPos() {
+        var pos = new Vec3((x + 0.5f) / 16f, 2 / 16f, (y + 0.5f) / 16f);
+        var state = getWorld().getBlockState(this.pos);
+        pos = VecHelper.rotateCentered(pos, CircuitBoardBlock.getAngleX(state), Direction.Axis.X);
+        pos = VecHelper.rotateCentered(pos, CircuitBoardBlock.getAngleY(state), Direction.Axis.Y);
+        return pos.add(this.pos.getX(), this.pos.getY(), this.pos.getZ());
     }
 
     public <T> T data() {

--- a/src/main/resources/assets/powergrid/lang/default/components.json
+++ b/src/main/resources/assets/powergrid/lang/default/components.json
@@ -74,5 +74,8 @@
   "powergrid.component.property.barretter_resistance": "Minimum Resistance",
 
   "powergrid.component.property.varistor_voltage": "Threshold Voltage",
-  "powergrid.component.property.varistor_voltage.summary": "Voltage around which the varistor starts to conduct major current"
+  "powergrid.component.property.varistor_voltage.summary": "Voltage around which the varistor starts to conduct major current",
+
+  "powergrid.component.property.current_fuse_max": "Max Current",
+  "powergrid.component.property.current_fuse_max.summary": "Current at which the fuse blows"
 }


### PR DESCRIPTION
Add the property names' text and add sparks when blowing.
I had to add `PREV_STATE` to do the sparks on the client because `FuseSwitchWire.wasBlown()` only seems to work on the server. I don't know if there's a better way to do it.