### PR TITLE
Fix transmission networks across chunk lifecycle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+---
+title: Power Grid documentation
+---
+
+# Power Grid documentation
+
+Operational documentation:
+
+- [Transmission network rebuild](operations/network-rebuild.md)
+- [Wire visibility synchronization](operations/wire-visibility-sync.md)
+
+Architecture decisions:
+
+- [ADR 0001: Bounded verified transmission rebuild](decisions/0001-bounded-verified-transmission-rebuild.md)

--- a/docs/decisions/0001-bounded-verified-transmission-rebuild.md
+++ b/docs/decisions/0001-bounded-verified-transmission-rebuild.md
@@ -91,6 +91,13 @@ The operation is a bounded server-thread state machine:
   player-position or login precondition. Its temporary entity-ticking tickets,
   structural validation and placeholder nodes are sufficient to complete a
   matching persisted network while no player is connected.
+- Normal placement remains incremental. A newly registered physical part stays
+  owned by its wire entity when its endpoint nodes are not ready on the first
+  connection attempt, and only that part receives at most three delayed
+  resolution attempts. Electrical block activation schedules island discovery
+  after its internal circuit has joined the endpoint networks. Discovery
+  requests produced during a running pass are carried into the next tick rather
+  than discarded.
 
 The scan is refused above 512 unique chunks. Chunk loading has three attempts
 per group, a 100-tick attempt timeout, a 20-tick retry delay and a five-minute
@@ -146,6 +153,12 @@ Loading a physical wire or rebuilding a line no longer requests a nested split
 while an outer split is preparing its replacement lines. The existing defensive
 guard remains available for unrelated invariant violations without producing
 routine stack traces during chunk loading.
+
+New cables and electrical blocks no longer depend on a later verified rebuild
+to become part of a previously rebuilt network. The bounded per-part retry
+handles only transient endpoint initialization and retains normal removal and
+unload ownership. Deferred island discovery makes topology changes visible to
+the solver without introducing a full-network rebuild on every placement.
 
 Startup takes longer in proportion to the number of discovered groups. The hard
 limits turn excessive load or a stuck chunk into a visible failure with all

--- a/docs/decisions/0001-bounded-verified-transmission-rebuild.md
+++ b/docs/decisions/0001-bounded-verified-transmission-rebuild.md
@@ -1,0 +1,169 @@
+---
+title: "ADR 0001: Bounded verified transmission rebuild"
+status: accepted
+date: 2026-07-28
+---
+
+# ADR 0001: Bounded verified transmission rebuild
+
+## Context
+
+Power Grid persists physical transmission-part registrations separately from
+the optimized logical lines used by the electrical solver. Long-distance
+networks can start with only part of their physical entities loaded. Older
+recovery behavior could compare stale saved endpoints with a newly loaded
+entity and remove the complete optimized line, orphaning otherwise healthy
+segments. Rebuilding only the optimized topology could not correct a stale
+physical-part registration.
+
+Loading every generated chunk is not acceptable. It has unbounded CPU, memory
+and disk I/O cost, may activate unrelated machinery, and cannot distinguish
+network chunks from unrelated terrain when no registration hint remains.
+
+## Decision
+
+Each server dimension runs a verified rebuild once during startup. Players may
+also request the same operation with `/powergrid rebuild`.
+
+The operation is a bounded server-thread state machine:
+
+- Persisted part records provide the discovery set.
+- Each atomic work unit contains a physical part's owner and endpoint chunks.
+- Units are greedily grouped under an eight-active-chunk limit.
+- Derived transmission lines are detached before the first group is loaded.
+  Island discovery, transmission ticks, solver work and state synchronization
+  remain paused for the dimension until a complete topology is available.
+- Temporary entity-ticking chunk tickets are acquired for one group at a time.
+- Loaded physical entities replace their prior logical registrations using
+  their current endpoints as authoritative data, but those registrations stay
+  detached from the solver graph during the scan. A present owner is refreshed
+  only when both of its current endpoints exist and validate against their
+  loaded electrical behaviours.
+- When the physical owner and saved endpoint pair match, terminal structure is
+  validated separately from late runtime electrical-behaviour readiness. The
+  saved registration is retained and reattached to the current owner if those
+  physical terminals still exist. Placeholder nodes keep it available to final
+  topology assembly until normal block initialization supplies the live nodes.
+- Electrical block initialization may refresh endpoint aliases and node
+  indexes during the scan, but tree tracing, line creation and line splitting
+  remain disabled until final topology assembly.
+- A stale endpoint mismatch replaces only the affected physical part.
+- A registration with no physical owner is removed only after its complete
+  chunk group was verified.
+- All temporary tickets are released before derived topology is rebuilt.
+- The endpoint index, node-to-part index and optimized logical lines are then
+  recreated once from the refreshed registrations.
+- Rebuilt transmission lines receive the already resolved, non-null endpoint
+  nodes. Persisted placeholder nodes remain valid when endpoint chunks unload
+  before final assembly.
+- A real node from a newly loaded endpoint supersedes its persisted
+  placeholder. New and split transmission lines are rebound to the endpoint
+  index after connection preparation and are admitted to the solver graph only
+  when both exact boundary nodes belong to the selected electrical network.
+- When a real terminal node unloads, it is replaced atomically with a passive
+  placeholder without detaching its healthy derived transmission line. The
+  existing line remains in the solver network and global graph, while every
+  endpoint alias and node-to-part index entry is migrated by identity.
+  Reloading the endpoint migrates the same line back to the real node without a
+  global rebuild.
+- Multiblock proxy endpoints may index a node whose canonical endpoint belongs
+  to the main block. This alias is preserved and the exact selected node is
+  repaired or merged into the target network before line admission.
+- A transmission segment stores its physical connection pair independently
+  from its canonical electrical nodes. Physical endpoints remain authoritative
+  for owner validation, chunk planning and persistence; topology traversal uses
+  canonical node identity. Alias index entries are retained while their proxy
+  blocks are loaded instead of being removed during node migration.
+- Ordinary endpoint registration binds and migrates nodes without implicitly
+  splitting a transmission line. Proxy-alias initialization requests a split
+  explicitly and only while topology resolution is enabled. Connection
+  preparation can therefore bind line boundaries without recursively
+  re-entering `TransmissionLine.splitAt`.
+- Solver and island-discovery work resumes only after final assembly succeeds.
+  An aborted scan restores a complete topology from the available records or,
+  if restoration itself fails, leaves transmission disconnected.
+- A present owner which is still waiting for late electrical-behaviour
+  initialization after its third registration attempt is observed for at most
+  100 ticks after isolation ends. This settlement phase does not invoke a
+  fourth refresh, retain tickets or extend the topology retry budget. It only
+  reconciles registrations recreated by the normal entity lifecycle.
+- The startup operation is server-driven and has no player-presence,
+  player-position or login precondition. Its temporary entity-ticking tickets,
+  structural validation and placeholder nodes are sufficient to complete a
+  matching persisted network while no player is connected.
+
+The scan is refused above 512 unique chunks. Chunk loading has three attempts
+per group, a 100-tick attempt timeout, a 20-tick retry delay and a five-minute
+overall deadline. A physical owner which is present but fails to recreate its
+registration receives at most three total attempts, separated by 20 ticks and
+using the already active group tickets. Final topology assembly retains a
+separate limit of three automatic retries per unresolved persisted part.
+
+Only one verified rebuild may run per dimension. A manual request does not
+supersede an active startup rebuild.
+
+## Consequences
+
+The rebuild repairs both stale physical-part registrations and derived logical
+topology without permanently loading the network. At most eight network chunks
+are held active at a time, limiting memory and tick load. Transmission is
+intentionally interrupted for the full verified scan so no partial topology can
+be observed by the solver.
+
+Endpoint loading can replace placeholder node objects without leaving an
+optimized line attached to the superseded object. A violated node-membership
+invariant now stops that individual topology operation before it can add an
+inconsistent wire to the solver.
+
+Normal chunk unload/reload cycles no longer orphan physical segments under a
+discarded terminal-node key or dismantle the healthy logical line which joins
+them. They neither keep network chunks loaded nor invoke the bounded verified
+rebuild. The compact derived topology stays resident and only its boundary node
+is exchanged when the endpoint leaves or returns.
+
+A startup batch no longer gives a present physical owner only one opportunity
+to recreate its registration. The separate three-attempt budget is bounded and
+diagnostic: exhaustion reports the exact identifiers, current endpoint
+validity and saved endpoints, while all temporary tickets are still released
+normally. The short post-isolation settlement window accounts for owners whose
+late behaviours become usable only after the scan releases isolation, without
+turning the window into an unbounded or hidden retry mechanism.
+
+A generator commutator or another late-initialized electrical block no longer
+causes a valid matching wire record to be deleted during headless startup.
+Structural terminal validation preserves the persisted segment independently
+of whether any player has logged in. A missing block, missing terminal, absent
+owner or changed endpoint pair still follows the bounded retry and diagnostic
+path.
+
+Loading a multiblock proxy no longer makes a healthy segment appear stale merely
+because the proxy block and the canonical node owner have different positions.
+The first rebuild after upgrading refreshes the existing saved records from
+their physical owners; later chunk loads reuse those physical identities
+without repeatedly replacing the segment.
+
+Loading a physical wire or rebuilding a line no longer requests a nested split
+while an outer split is preparing its replacement lines. The existing defensive
+guard remains available for unrelated invariant violations without producing
+routine stack traces during chunk loading.
+
+Startup takes longer in proportion to the number of discovered groups. The hard
+limits turn excessive load or a stuck chunk into a visible failure with all
+temporary tickets released.
+
+The operation cannot recover a physical entity for which all persisted part
+records and chunk hints were already lost. A pre-loss world backup remains the
+authoritative recovery mechanism for that case.
+
+## Compatibility and rollback
+
+The topology and rebuild changes run on the logical server and do not add or
+alter network packets, so unmodified clients of the matching mod version remain
+protocol-compatible on a dedicated server. In single player the universal mod
+jar runs the same logic in the integrated server.
+
+The physical connection pair continues to use the existing `Node1` and `Node2`
+saved-data fields. Rolling back to the official mod therefore preserves
+physical entities and reads the saved part data without a schema migration.
+The automatic verified rebuild and the manual repair command are no longer
+available after rollback.

--- a/docs/operations/network-rebuild.md
+++ b/docs/operations/network-rebuild.md
@@ -156,6 +156,25 @@ verified to belong to the target electrical network. This prevents a
 placeholder left over from chunk loading from being inserted as an
 out-of-network wire endpoint.
 
+## Incremental additions
+
+Placing a new electrical block, cable or cord does not start a verified rebuild.
+The normal entity lifecycle attaches the new physical part to the existing
+derived topology and schedules island discovery after the block's internal
+circuit has joined its endpoint networks.
+
+If two distinct physical endpoints temporarily resolve to an incomplete or
+shared node while their block entities are initializing, the physical owner now
+keeps its persisted part registration instead of dropping the reference. The
+server retries only that unresolved part at most three times, 20 ticks apart,
+and processes at most 16 such retries in one tick. A successful retry schedules
+the same island-discovery path as an immediate connection.
+
+Island-discovery requests raised while a discovery pass is already running are
+deferred to the next tick instead of being discarded. These incremental paths
+do not load chunks, do not interrupt the complete dimension network and do not
+consume the verified rebuild's separate retry budget.
+
 ## Safety bounds
 
 - At most 8 chunks are temporarily active at once.

--- a/docs/operations/network-rebuild.md
+++ b/docs/operations/network-rebuild.md
@@ -1,0 +1,259 @@
+---
+title: Transmission network rebuild
+---
+
+# Transmission network rebuild
+
+The server performs one verified transmission rebuild for every dimension
+during each startup. It also adds:
+
+```text
+/powergrid rebuild
+```
+
+The command requires Minecraft permission level 2 (operator). It affects only
+the command source's current dimension; a dedicated-server console invocation
+uses its current command level, normally the overworld. Existing Power Grid
+debug, source, performance and configuration commands keep their level 3
+permission requirement.
+
+Only one verified rebuild can run in a dimension at a time. If the automatic
+startup rebuild is still active, the command reports that a rebuild is already
+running. An accepted manual invocation has a per-dimension 60-second cooldown
+to limit accidental or malicious repeated work.
+
+## What the command does
+
+`/powergrid rebuild` starts the same asynchronous state machine used during
+startup. The command returns after scheduling the job; the server thread
+advances one bounded phase per tick and reports the final result to the command
+source.
+
+For the current dimension, the command:
+
+1. Uses saved transmission-part registrations to discover only chunks which
+   are known to contain a wire owner or one of its endpoints.
+2. Refuses the operation before isolation when the plan exceeds the
+   512-unique-chunk safety limit.
+3. Temporarily pauses the dimension's derived transmission topology, island
+   discovery, electrical solver work and state synchronization. Physical block
+   and wire entities continue their normal server ticks.
+4. Adds entity-ticking tickets for at most eight chunks at a time, verifies the
+   physical owners and their terminal structures, refreshes stale
+   registrations, and releases each batch before loading the next one.
+5. Recreates the endpoint indexes and optimized transmission lines once, after
+   the verified scan has finished, then resumes normal electrical simulation.
+6. Reports the physical-part count, unique chunks, refreshed, recovered and
+   removed records, final line count and elapsed time. A partial or failed job
+   directs the operator to the diagnostic server log.
+
+The command does not break or replace placed blocks, does not scan every
+generated chunk, and does not keep network chunks permanently loaded. All
+temporary tickets are released after a batch, on completion, on failure,
+dimension unload and server shutdown; the ticket type also has an expiry.
+
+## Verified rebuild phases
+
+The rebuild treats physical wire and cord entities as the source of truth:
+
+1. Read the persisted physical-part registrations and collect each part's last
+   known owner chunk and endpoint chunks.
+2. Detach the derived transmission topology and pause transmission-line island
+   discovery and solver work. Physical entities continue ticking, but no
+   partially refreshed topology can enter the solver.
+3. Load owner and endpoint chunks together in bounded groups, wait until
+   entities are loaded and ticking, and refresh the physical owner's electrical
+   registrations from its current endpoints while they remain detached from the
+   solver graph. A present owner is refreshed only after both of its current
+   endpoints exist and validate against their loaded electrical behaviours.
+4. If a loaded physical owner reports the same endpoint pair as its saved
+   registration, but a block such as the generator commutator has not created
+   its late electrical behaviour yet, retain and reattach that saved
+   registration after verifying that both physical terminal structures still
+   exist. The final topology uses placeholder nodes until the normal block
+   lifecycle supplies the live nodes.
+5. Replace only the stale logical part when its saved endpoints differ from
+   the physical entity. The repair never removes an entire optimized line just
+   because one segment is stale.
+6. Remove a saved registration only after its complete owner/endpoint group was
+   entity-ticking and no physical owner existed.
+7. Release that group's temporary chunk tickets before processing the next
+   group.
+8. Restore the endpoint and node indexes, assemble fresh optimized logical
+   lines once from the refreshed registrations, and only then resume island
+   discovery and solver work.
+9. If a present owner was still waiting for late block-behaviour initialization
+   after its third bounded refresh attempt, observe normal registration for at
+   most 100 additional ticks after isolation ends. This settlement phase makes
+   no fourth rebuild attempt and acquires no chunk ticket. It only accepts a
+   registration that the physical owner recreates through its normal tick or
+   initialization lifecycle.
+
+The verified startup rebuild does not depend on a player being logged in or
+near the network. Server-owned entity-ticking tickets drive the bounded scan.
+Matching persisted registrations can be retained from the physical blocks and
+wire entities before a late runtime electrical behaviour becomes available, so
+player login, movement and manual rebuilds are not initialization triggers.
+
+Electrical block initialization during the verified scan may update endpoint
+and node indexes, but it cannot start tree tracing, line creation or line
+splitting. Those topology operations are enabled only for the single final
+assembly phase.
+
+Placed blocks, physical wire entities and cords are not removed. The rebuild
+temporarily interrupts transmission while the verified scan is active.
+
+After the verified scan, passive transmission topology uses placeholder nodes
+for endpoints whose chunks unload again. The network therefore does not keep
+its chunks permanently loaded.
+
+Unloading a terminal does not detach a healthy derived transmission line.
+Instead, it atomically rebinds the existing line, every endpoint alias and every
+persisted physical segment from the departing block node to a placeholder node.
+The node-to-part index never keeps the discarded block node as its only key,
+and the optimized line remains connected to the same solver network and global
+graph. When the endpoint loads again, normal node registration migrates the
+line and indexed segment set from the placeholder to the real node. Island
+discovery is scheduled after both transitions.
+
+This unload/reload path does not consume the automatic rebuild retry budget and
+does not acquire chunk tickets. A manual `/powergrid rebuild` may still be
+needed once after installing the repair to correct a world whose runtime index
+was already orphaned by an older build. It must not be required again merely
+because a player leaves and revisits the repaired endpoint chunks.
+
+Preserving the derived topology means the server retains the compact logical
+lines assembled by the verified rebuild even when their physical chunks are
+absent. It does not retain wire entities, block entities or chunks. The solver
+and graph memory cost therefore follows the persisted electrical network size,
+not the number of loaded terrain chunks.
+
+When an endpoint chunk loads again, its real node supersedes the persisted
+placeholder and all indexed transmission parts migrate to that real node.
+Multiblock proxy endpoints are valid aliases: an endpoint on a secondary block
+may resolve to a node canonically owned by the main block, so their endpoint
+objects do not have to be equal. Each persisted segment therefore retains its
+physical connection endpoints separately from its resolved canonical nodes.
+The physical pair is used for owner validation, chunk planning and saved data;
+the canonical nodes are used for topology traversal and solver connections.
+Tree traversal selects a segment side by canonical node identity rather than by
+comparing the physical alias with the canonical endpoint.
+
+Ordinary endpoint registration binds and migrates the selected node without
+requesting a topology split. Callers which genuinely introduce a proxy alias
+request the split explicitly after binding. This separation prevents
+`TransmissionLine.splitAt` from re-entering itself when its connection
+preparation registers the same boundary endpoints.
+
+The existing `Node1` and `Node2` saved-data keys now retain the physical
+connection pair. No world-data migration or new format version is required.
+The first verified rebuild after upgrading from an earlier server fix refreshes
+these values from the loaded physical owners.
+
+Before a newly assembled or split transmission line enters the solver graph,
+both of its boundary nodes are rebound to the current endpoint index and
+verified to belong to the target electrical network. This prevents a
+placeholder left over from chunk loading from being inserted as an
+out-of-network wire endpoint.
+
+## Safety bounds
+
+- At most 8 chunks are temporarily active at once.
+- A physical part's owner and endpoint chunks are never split across groups.
+- At most 512 unique chunks may be included in one rebuild. A larger rebuild is
+  refused rather than partially scanning the dimension.
+- Each chunk group receives at most 3 load attempts.
+- Each attempt has a 100-tick timeout and retries are separated by 20 ticks.
+- A loaded physical owner which does not recreate its saved registration
+  receives at most 3 registration attempts in total, separated by 20 ticks.
+  These attempts reuse the current bounded chunk group; they do not acquire
+  additional tickets.
+- A matching saved registration whose physical owner and terminal structures
+  are present is retained immediately. It does not consume more attempts merely
+  because a late runtime electrical behaviour is not ready.
+- An unresolved present owner receives one post-isolation observation window of
+  at most 100 ticks. The window does not call `makeWire`, does not retry the
+  rebuild and does not load chunks. It can finish early when every late
+  registration has returned.
+- A complete verified rebuild has a 5-minute deadline.
+- Temporary tickets are explicitly released after every group, on failure, on
+  dimension unload and on server shutdown. They also expire automatically.
+
+The verified scan does not permanently force block or random ticks outside the
+normal server simulation rules.
+
+If a chunk batch times out or the verified scan otherwise aborts, the server
+first attempts to assemble a consistent topology from the registrations already
+available. If even that recovery step fails, all derived transmission lines are
+left disconnected instead of exposing a partial graph to the solver.
+
+## Topology retry and reporting
+
+The command reports physical parts, unique chunks, refreshed, recovered and
+removed registrations, final logical lines and elapsed time. A part which
+cannot be assembled into the final topology immediately receives at most three
+automatic retries, spaced 20 ticks apart. The queue processes no more than 16
+retries per server tick. A part is removed from the retry queue after its third
+failed attempt; it is not removed from persisted world data.
+
+Each failed attempt logs the part identifier, endpoints, resolved nodes, last
+known chunk, owner load state and failure reason. If the retry limit is
+exhausted, preserve the world backup and inspect the server log before running
+the command again.
+
+Physical-owner registration retries have a separate three-attempt budget from
+final topology retries. Only the unresolved identifiers are refreshed again.
+An owner is not destructively refreshed while either current endpoint is absent
+or structurally invalid. Runtime electrical-behaviour readiness alone does not
+make a matching physical registration stale. If the budget is exhausted, the
+server logs each identifier
+together with the owner type and position, both current endpoints and their
+validity, and the saved physical endpoint pair.
+
+After final topology assembly, the bounded settlement window reconciles only
+registrations that return naturally. A returned identifier moves into the
+verified count and the final line/part totals are sampled again. An identifier
+which is still absent at the deadline remains in `unresolved parts`; it is not
+silently treated as a successful startup rebuild.
+
+An error saying `Both nodes of a wire must be part of the network` during
+`TransmissionLine.splitAt` indicates that a logical line retained a stale node
+while its endpoint was loading. It is an electrical-topology invariant report,
+not evidence that Minecraft skipped or deleted the transformer, commutator or
+wire entity named later in the stack trace.
+
+An exception saying `Prepared transmission line endpoints do not belong to the
+target network` from an `ElectricBlockEntity` during a numbered verified-rebuild
+batch means topology resolution escaped the isolated scan phase. It must not be
+treated as a normal retry or ignored: the affected block tick can be caught by
+an error-handling mod before the final rebuild completes.
+
+`Replacing stale transmission part` is expected only when a physical owner
+reports a genuinely different connection pair from its saved record. Repeated
+messages for the same identifier where only a multiblock proxy coordinate
+differs from its main block are not normal. They indicate that physical and
+canonical endpoints were conflated. Such messages must not continue after a
+successful verified rebuild when players load the affected chunks.
+
+`Prevented a double split call` is a defensive guard report and not a thrown
+entity-tick exception. It is nevertheless not expected during the final rebuild
+or when a player loads network chunks. Repeated reports mean endpoint binding
+has incorrectly requested another split while a line split is already
+preparing its new boundaries.
+
+Transmission lines are constructed from the non-null nodes resolved during
+topology assembly. An endpoint that unloads between the verified scan and final
+assembly uses its persisted placeholder node; it is never silently connected
+to the graph's null/ground node.
+
+## Recovery limit
+
+The scan can discover unloaded physical owners from saved part records. It can
+also recover a missing conductor registration when another saved conductor of
+the same physical cord leads the scan to that entity.
+
+It cannot safely discover a physical wire when every saved registration and
+chunk hint for that entity was already deleted by an older repair build.
+Searching every generated chunk would impose unbounded startup cost and could
+generate or load unrelated terrain. Restore a backup made before those records
+were lost when guaranteed recovery of that case is required.

--- a/docs/operations/wire-visibility-sync.md
+++ b/docs/operations/wire-visibility-sync.md
@@ -8,19 +8,20 @@ Power Grid wires are persistent entities. Their electrical state is authoritativ
 on the server, while their item, endpoints and render geometry are sent to each
 client through the existing Power Grid entity-data packet.
 
-The server sends the complete wire data directly to a player immediately before
-Minecraft sends that wire entity's spawn bundle. Hanging wires and cords then
-receive a second packet containing the exact terminal positions already
-calculated by the server, after the spawn bundle has been queued. Both packets
-use formats already supported by the official client.
+Minecraft sends the wire entity's spawn bundle first. The server then sends the
+complete wire data directly to that exact player, followed by a second packet
+containing the terminal positions already calculated by the server. Render-only
+geometry broadcasts are restricted to players whose tracking session has
+completed. All packets use formats already supported by the official client.
 
 The ordering is intentional. The official client can retain one entity-data
 packet while waiting for the entity with that numeric id to spawn. A render-only
-geometry packet left behind by an earlier tracking session does not contain the
-wire item, so applying it to a fresh entity can fail during render setup. The
-new complete pre-spawn packet replaces any such stale entry, initializes the
-wire item and endpoints when the entity joins, and only then is the render-only
-geometry sent.
+geometry packet does not contain the wire item, so applying it to a fresh entity
+can fail during render setup. Excluding not-yet-paired players from ordinary
+geometry broadcasts prevents that packet from arriving before spawn. Once
+spawned, complete material and endpoint state is sent before render geometry.
+Players are removed from the geometry recipient set before Minecraft ends their
+tracking session, preventing a late geometry packet from surviving the removal.
 
 This applies whenever the player starts tracking:
 
@@ -34,12 +35,13 @@ Packet formats, packet registration and the entity registry are unchanged.
 The same universal mod jar still contains the server logic when playing in an
 integrated single-player server.
 
-The synchronization is event-driven. It sends one full-data packet during
-pairing with a wire. Hanging wires, power cords and string-light cords also send
-one existing terminal-geometry packet after pairing. Block-mounted wires need
-only the full packet because their segment geometry is stored directly in that
-data. The repair does not add a periodic retry or broadcast loop. Normal wire
-updates continue to use the existing tracking broadcast.
+The synchronization is event-driven. It sends one full-data packet after the
+spawn bundle during pairing with a wire. Hanging wires, power cords and
+string-light cords also receive one existing terminal-geometry packet
+immediately afterward. Block-mounted wires need only the full packet because
+their segment geometry is stored directly in that data. The repair does not add
+a periodic retry or broadcast loop. Normal geometry updates are sent only to
+the entity's established tracking sessions.
 
 ## Observable behavior
 
@@ -57,10 +59,13 @@ official client removes that local wire entity on its next tick. The server
 entity and electrical connection remain healthy, which explains why power
 continues and why visibility can differ between players.
 
-After the repair, full material and endpoint data still arrives first. The
-server-calculated terminal geometry follows the spawn bundle, so curve
-initialization does not depend on client chunk or block-entity timing and a
-geometry-only packet cannot replace the full deferred initialization packet.
+After the repair, full material and endpoint data arrives before terminal
+geometry for every completed pairing. The server-calculated geometry therefore
+does not depend on client chunk or block-entity timing. Updated clients also
+retain complete deferred data when a render-only packet arrives out of order,
+ignore geometry until wire material exists, and clear deferred entity data when
+leaving a world. These client guards complement the server-side ordering but
+are not required for an official client connecting to a repaired server.
 
 This repair does not:
 
@@ -68,7 +73,7 @@ This repair does not:
 - change current flow or resistance;
 - load or retain chunks;
 - increase entity tracking distance;
-- change any client class or resource.
+- change packet formats or require a modified client.
 
 If a wire remains invisible for every player while its complete entity bounding
 box is visible with Minecraft's entity-hitbox debug view, investigate a

--- a/docs/operations/wire-visibility-sync.md
+++ b/docs/operations/wire-visibility-sync.md
@@ -8,11 +8,19 @@ Power Grid wires are persistent entities. Their electrical state is authoritativ
 on the server, while their item, endpoints and render geometry are sent to each
 client through the existing Power Grid entity-data packet.
 
-The server sends the complete wire data directly to a player
-after Minecraft sends that wire entity's spawn bundle. Hanging wires and cords
-then receive a second packet containing the exact terminal positions already
-calculated by the server. Both packets use formats already supported by the
-official client.
+The server sends the complete wire data directly to a player immediately before
+Minecraft sends that wire entity's spawn bundle. Hanging wires and cords then
+receive a second packet containing the exact terminal positions already
+calculated by the server, after the spawn bundle has been queued. Both packets
+use formats already supported by the official client.
+
+The ordering is intentional. The official client can retain one entity-data
+packet while waiting for the entity with that numeric id to spawn. A render-only
+geometry packet left behind by an earlier tracking session does not contain the
+wire item, so applying it to a fresh entity can fail during render setup. The
+new complete pre-spawn packet replaces any such stale entry, initializes the
+wire item and endpoints when the entity joins, and only then is the render-only
+geometry sent.
 
 This applies whenever the player starts tracking:
 
@@ -26,12 +34,12 @@ Packet formats, packet registration and the entity registry are unchanged.
 The same universal mod jar still contains the server logic when playing in an
 integrated single-player server.
 
-The synchronization is event-driven. It sends one full-data packet when a
-player starts tracking a wire. Hanging wires, power cords and string-light cords
-also send one existing terminal-geometry packet. Block-mounted wires need only
-the full packet because their segment geometry is stored directly in that data.
-The repair does not add a periodic retry or broadcast loop. Normal wire updates
-continue to use the existing tracking broadcast.
+The synchronization is event-driven. It sends one full-data packet during
+pairing with a wire. Hanging wires, power cords and string-light cords also send
+one existing terminal-geometry packet after pairing. Block-mounted wires need
+only the full packet because their segment geometry is stored directly in that
+data. The repair does not add a periodic retry or broadcast loop. Normal wire
+updates continue to use the existing tracking broadcast.
 
 ## Observable behavior
 
@@ -50,9 +58,9 @@ entity and electrical connection remain healthy, which explains why power
 continues and why visibility can differ between players.
 
 After the repair, full material and endpoint data still arrives first. The
-server-calculated terminal geometry immediately follows it, before the next
-client entity tick, so curve initialization does not depend on client chunk or
-block-entity timing.
+server-calculated terminal geometry follows the spawn bundle, so curve
+initialization does not depend on client chunk or block-entity timing and a
+geometry-only packet cannot replace the full deferred initialization packet.
 
 This repair does not:
 

--- a/docs/operations/wire-visibility-sync.md
+++ b/docs/operations/wire-visibility-sync.md
@@ -1,0 +1,67 @@
+---
+title: Wire visibility synchronization
+---
+
+# Wire visibility synchronization
+
+Power Grid wires are persistent entities. Their electrical state is authoritative
+on the server, while their item, endpoints and render geometry are sent to each
+client through the existing Power Grid entity-data packet.
+
+The server sends the complete wire data directly to a player
+after Minecraft sends that wire entity's spawn bundle. Hanging wires and cords
+then receive a second packet containing the exact terminal positions already
+calculated by the server. Both packets use formats already supported by the
+official client.
+
+This applies whenever the player starts tracking:
+
+- hanging wires;
+- block-mounted wires;
+- power cords;
+- string-light cords.
+
+Dedicated-server clients do not need this change for protocol compatibility.
+Packet formats, packet registration and the entity registry are unchanged.
+The same universal mod jar still contains the server logic when playing in an
+integrated single-player server.
+
+The synchronization is event-driven. It sends one full-data packet when a
+player starts tracking a wire. Hanging wires, power cords and string-light cords
+also send one existing terminal-geometry packet. Block-mounted wires need only
+the full packet because their segment geometry is stored directly in that data.
+The repair does not add a periodic retry or broadcast loop. Normal wire updates
+continue to use the existing tracking broadcast.
+
+## Observable behavior
+
+A client which previously received the entity spawn without usable render data
+could see an invisible wire even though the server still simulated current
+through it. Relogging or another player observing the same location could make
+the wire reappear because each client has independent entity-tracking state.
+
+The earlier repair sent only the persisted endpoint descriptions. During chunk
+arrival, a client can know those block coordinates before the corresponding
+electrical blocks or block entities are ready. It then substitutes block
+centres for the real terminal offsets. For a taut wire, that temporary geometry
+can be longer than the saved placed length, producing an invalid curve; the
+official client removes that local wire entity on its next tick. The server
+entity and electrical connection remain healthy, which explains why power
+continues and why visibility can differ between players.
+
+After the repair, full material and endpoint data still arrives first. The
+server-calculated terminal geometry immediately follows it, before the next
+client entity tick, so curve initialization does not depend on client chunk or
+block-entity timing.
+
+This repair does not:
+
+- rebuild electrical topology;
+- change current flow or resistance;
+- load or retain chunks;
+- increase entity tracking distance;
+- change any client class or resource.
+
+If a wire remains invisible for every player while its complete entity bounding
+box is visible with Minecraft's entity-hitbox debug view, investigate a
+separate client-side renderer or culling issue instead.

--- a/fabric/src/main/generated/assets/powergrid/lang/en_us.json
+++ b/fabric/src/main/generated/assets/powergrid/lang/en_us.json
@@ -1,4 +1,12 @@
 {
+  "powergrid.command.rebuild.cooldown": "Wait %1$s seconds before rebuilding the network again.",
+  "powergrid.command.rebuild.failed": "Rebuild failed after %1$s attempts. Temporary chunks were released; check the log.",
+  "powergrid.command.rebuild.no_level": "The dimension is not available yet. Wait for the server to finish loading.",
+  "powergrid.command.rebuild.partial": "Partial verified rebuild: %1$s parts unresolved and %2$s parts queued for automatic retry (at most %3$s attempts). Check the log.",
+  "powergrid.command.rebuild.running": "A verified rebuild is already running in this dimension.",
+  "powergrid.command.rebuild.start": "Verified rebuild started: %1$s parts, %2$s unique chunks in %3$s batches. Chunks will be released progressively.",
+  "powergrid.command.rebuild.success": "Network verified: %1$s parts, %2$s chunks, %3$s records refreshed, %4$s recovered, %5$s removed, %6$s final lines, %7$s ms.",
+  "powergrid.command.rebuild.too_many_chunks": "Rebuild refused: the network needs %1$s chunks, above the safety limit of %2$s.",
   "block.powergrid.acid": "Acid",
   "block.powergrid.alarm_bell": "Alarm Bell",
   "block.powergrid.andesite_encased_crt": "Andesite Encased CRT",

--- a/fabric/src/main/java/org/patryk3211/powergrid/fabric/PowerGridClientImpl.java
+++ b/fabric/src/main/java/org/patryk3211/powergrid/fabric/PowerGridClientImpl.java
@@ -56,7 +56,10 @@ public class PowerGridClientImpl implements ClientModInitializer, ModelLoadingPl
         WorldRenderEvents.BEFORE_ENTITIES.register(this::onLevelRender);
 
         // Register platform events
-        ClientWorldEvents.UNLOAD.register(ClientElectricNetwork::unloadWorld);
+        ClientWorldEvents.UNLOAD.register((client, world) -> {
+            ClientElectricNetwork.unloadWorld(client, world);
+            EntityDataS2CPacket.clearDeferredData();
+        });
     }
 
     private void onLevelRender(WorldRenderContext context) {

--- a/forge/src/main/generated/assets/powergrid/lang/en_us.json
+++ b/forge/src/main/generated/assets/powergrid/lang/en_us.json
@@ -1,4 +1,12 @@
 {
+  "powergrid.command.rebuild.cooldown": "Wait %1$s seconds before rebuilding the network again.",
+  "powergrid.command.rebuild.failed": "Rebuild failed after %1$s attempts. Temporary chunks were released; check the log.",
+  "powergrid.command.rebuild.no_level": "The dimension is not available yet. Wait for the server to finish loading.",
+  "powergrid.command.rebuild.partial": "Partial verified rebuild: %1$s parts unresolved and %2$s parts queued for automatic retry (at most %3$s attempts). Check the log.",
+  "powergrid.command.rebuild.running": "A verified rebuild is already running in this dimension.",
+  "powergrid.command.rebuild.start": "Verified rebuild started: %1$s parts, %2$s unique chunks in %3$s batches. Chunks will be released progressively.",
+  "powergrid.command.rebuild.success": "Network verified: %1$s parts, %2$s chunks, %3$s records refreshed, %4$s recovered, %5$s removed, %6$s final lines, %7$s ms.",
+  "powergrid.command.rebuild.too_many_chunks": "Rebuild refused: the network needs %1$s chunks, above the safety limit of %2$s.",
   "block.powergrid.acid": "Acid",
   "block.powergrid.alarm_bell": "Alarm Bell",
   "block.powergrid.andesite_encased_crt": "Andesite Encased CRT",

--- a/forge/src/main/java/org/patryk3211/powergrid/forge/ForgeClientEvents.java
+++ b/forge/src/main/java/org/patryk3211/powergrid/forge/ForgeClientEvents.java
@@ -28,6 +28,7 @@ public class ForgeClientEvents {
     public static void clientWorldUnload(LevelEvent.Unload unload) {
         if(unload.getLevel().isClientSide() && unload.getLevel() instanceof ClientLevel world) {
             ClientElectricNetwork.unloadWorld(Minecraft.getInstance(), world);
+            EntityDataS2CPacket.clearDeferredData();
         }
     }
 

--- a/src/main/java/org/patryk3211/powergrid/collections/ModdedCommands.java
+++ b/src/main/java/org/patryk3211/powergrid/collections/ModdedCommands.java
@@ -23,17 +23,18 @@ import net.minecraft.commands.Commands;
 import org.patryk3211.powergrid.commands.ConfigCommand;
 import org.patryk3211.powergrid.commands.DebugCommand;
 import org.patryk3211.powergrid.commands.PerformanceCommand;
+import org.patryk3211.powergrid.commands.RebuildNetworkCommand;
 import org.patryk3211.powergrid.commands.SourceCommand;
 
 public class ModdedCommands {
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context, Commands.CommandSelection selection) {
         LiteralArgumentBuilder<CommandSourceStack> root = Commands.literal("powergrid")
-                .requires(cs -> cs.hasPermission(3))
-                .then(PerformanceCommand.register())
-                .then(DebugCommand.register())
-                .then(SourceCommand.register())
-                .then(ConfigCommand.reset())
-                .then(ConfigCommand.ignore());
+                .then(RebuildNetworkCommand.register())
+                .then(PerformanceCommand.register().requires(cs -> cs.hasPermission(3)))
+                .then(DebugCommand.register().requires(cs -> cs.hasPermission(3)))
+                .then(SourceCommand.register().requires(cs -> cs.hasPermission(3)))
+                .then(ConfigCommand.reset().requires(cs -> cs.hasPermission(3)))
+                .then(ConfigCommand.ignore().requires(cs -> cs.hasPermission(3)));
 
         dispatcher.register(root);
     }

--- a/src/main/java/org/patryk3211/powergrid/commands/RebuildCooldown.java
+++ b/src/main/java/org/patryk3211/powergrid/commands/RebuildCooldown.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.commands;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+final class RebuildCooldown<K> {
+    private final Map<K, Long> nextAllowedTicks = new WeakHashMap<>();
+    private final long cooldownTicks;
+
+    RebuildCooldown(long cooldownTicks) {
+        if(cooldownTicks <= 0)
+            throw new IllegalArgumentException("Cooldown must be positive");
+        this.cooldownTicks = cooldownTicks;
+    }
+
+    synchronized boolean tryAcquire(K key, long currentTick) {
+        if(remainingTicks(key, currentTick) > 0)
+            return false;
+        nextAllowedTicks.put(key, currentTick + cooldownTicks);
+        return true;
+    }
+
+    synchronized long remainingTicks(K key, long currentTick) {
+        var nextAllowedTick = nextAllowedTicks.get(key);
+        if(nextAllowedTick == null)
+            return 0;
+        return Math.max(0, nextAllowedTick - currentTick);
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/commands/RebuildNetworkCommand.java
+++ b/src/main/java/org/patryk3211/powergrid/commands/RebuildNetworkCommand.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.commands;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import org.patryk3211.powergrid.PowerGrid;
+import org.patryk3211.powergrid.electricity.GlobalElectricNetworks;
+import org.patryk3211.powergrid.electricity.TransmissionNetworkRebuildJob;
+import org.patryk3211.powergrid.electricity.WorldNetworks;
+
+import static net.minecraft.commands.Commands.literal;
+
+public final class RebuildNetworkCommand {
+    static final long COOLDOWN_TICKS = 20L * 60L;
+    private static final RebuildCooldown<ServerLevel> COOLDOWN = new RebuildCooldown<>(COOLDOWN_TICKS);
+
+    private RebuildNetworkCommand() {
+    }
+
+    public static ArgumentBuilder<CommandSourceStack, ?> register() {
+        return literal("rebuild")
+                .requires(source -> source.hasPermission(2))
+                .executes(context -> execute(context.getSource()));
+    }
+
+    private static int execute(CommandSourceStack source) {
+        ServerLevel level = source.getLevel();
+        if(level == null)
+            level = source.getServer().overworld();
+        if(level == null) {
+            source.sendFailure(Component.translatable("powergrid.command.rebuild.no_level"));
+            return 0;
+        }
+
+        var targetLevel = level;
+        var networks = GlobalElectricNetworks.getWorldNetworks(targetLevel);
+        if(networks.verifiedRebuildInProgress()) {
+            source.sendFailure(Component.translatable("powergrid.command.rebuild.running"));
+            return 0;
+        }
+
+        var currentTick = targetLevel.getGameTime();
+        if(!COOLDOWN.tryAcquire(targetLevel, currentTick)) {
+            var remainingTicks = COOLDOWN.remainingTicks(targetLevel, currentTick);
+            var remainingSeconds = Math.max(1, (remainingTicks + 19) / 20);
+            source.sendFailure(Component.translatable(
+                    "powergrid.command.rebuild.cooldown",
+                    remainingSeconds
+            ));
+            return 0;
+        }
+
+        try {
+            var start = networks.startVerifiedRebuild(new TransmissionNetworkRebuildJob.Listener() {
+                @Override
+                public void completed(TransmissionNetworkRebuildJob.Outcome outcome) {
+                    if(outcome.complete()) {
+                        source.sendSystemMessage(Component.translatable(
+                                "powergrid.command.rebuild.success",
+                                outcome.rebuild().parts(),
+                                outcome.uniqueChunks(),
+                                outcome.refreshedRecords(),
+                                outcome.recoveredRecords(),
+                                outcome.removedRecords(),
+                                outcome.rebuild().linesAfter(),
+                                outcome.elapsedMillis()
+                        ).withStyle(ChatFormatting.GREEN));
+                        return;
+                    }
+
+                    source.sendFailure(Component.translatable(
+                            "powergrid.command.rebuild.partial",
+                            outcome.unresolvedParts(),
+                            outcome.rebuild().retryingParts(),
+                            outcome.rebuild().retryLimit()
+                    ));
+                }
+
+                @Override
+                public void failed(TransmissionNetworkRebuildJob.Failure failure) {
+                    source.sendFailure(Component.translatable(
+                            "powergrid.command.rebuild.failed",
+                            failure.attempts()
+                    ));
+                }
+            });
+
+            if(start.status() == WorldNetworks.VerifiedRebuildStartStatus.ALREADY_RUNNING) {
+                source.sendFailure(Component.translatable("powergrid.command.rebuild.running"));
+                return 0;
+            }
+            if(start.status() == WorldNetworks.VerifiedRebuildStartStatus.TOO_MANY_CHUNKS) {
+                source.sendFailure(Component.translatable(
+                        "powergrid.command.rebuild.too_many_chunks",
+                        start.requestedChunks(),
+                        TransmissionNetworkRebuildJob.MAX_UNIQUE_CHUNKS
+                ));
+                return 0;
+            }
+
+            var info = start.info();
+            source.sendSystemMessage(Component.translatable(
+                    "powergrid.command.rebuild.start",
+                    info.parts(),
+                    info.uniqueChunks(),
+                    info.batches()
+            ).withStyle(ChatFormatting.GRAY));
+            return Command.SINGLE_SUCCESS;
+        } catch(RuntimeException exception) {
+            PowerGrid.LOGGER.error(
+                    "Transmission network rebuild requested by {} failed in {}",
+                    source.getTextName(),
+                    targetLevel.dimension().location(),
+                    exception
+            );
+            source.sendFailure(Component.translatable(
+                    "powergrid.command.rebuild.failed",
+                    0
+            ));
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/electricity/GlobalElectricNetworks.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/GlobalElectricNetworks.java
@@ -203,6 +203,13 @@ public class GlobalElectricNetworks {
         }
     }
 
+    public static void nodeHolderInternalsConnected(ElectricBehaviour behaviour) {
+        var worldNetworks = getWorldNetworks(behaviour.blockEntity.getLevel());
+        for(OwnedFloatingNode node : behaviour.getExternalNodes()) {
+            worldNetworks.scheduleIslandDiscovery(node.getNetwork());
+        }
+    }
+
     public static void configsReloaded() {
         var cSolver = ModdedConfigs.server().electricity.solver;
         var backend = cSolver.solverBackend.get();

--- a/src/main/java/org/patryk3211/powergrid/electricity/GlobalElectricNetworks.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/GlobalElectricNetworks.java
@@ -50,6 +50,8 @@ public class GlobalElectricNetworks {
 
     public static void preTick(Level world) {
         var networks = worldNetworks.get(world);
+        if(networks == null && world instanceof ServerLevel)
+            networks = getWorldNetworks(world);
         if(networks == null)
             return;
         networks.preTick();
@@ -63,7 +65,9 @@ public class GlobalElectricNetworks {
     }
 
     public static void unloadWorld(ServerLevel world) {
-        worldNetworks.remove(world);
+        var networks = worldNetworks.remove(world);
+        if(networks != null)
+            networks.close();
     }
 
     @Environment(EnvType.CLIENT)

--- a/src/main/java/org/patryk3211/powergrid/electricity/RebuildBatchPlanner.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/RebuildBatchPlanner.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+final class RebuildBatchPlanner {
+    private RebuildBatchPlanner() {
+    }
+
+    record Unit<K, V>(K key, Set<V> required) {
+        Unit {
+            required = Set.copyOf(required);
+            if(required.isEmpty())
+                throw new IllegalArgumentException("A rebuild unit must require at least one value");
+        }
+    }
+
+    record Batch<K, V>(List<K> keys, Set<V> required) {
+        Batch {
+            keys = List.copyOf(keys);
+            required = Set.copyOf(required);
+        }
+    }
+
+    static <K, V> List<Batch<K, V>> plan(Collection<Unit<K, V>> units, int maxActiveValues) {
+        if(maxActiveValues <= 0)
+            throw new IllegalArgumentException("maxActiveValues must be positive");
+
+        var batches = new ArrayList<Batch<K, V>>();
+        var keys = new ArrayList<K>();
+        var required = new LinkedHashSet<V>();
+        for(var unit : units) {
+            if(unit.required().size() > maxActiveValues) {
+                throw new IllegalArgumentException(
+                        "A rebuild unit requires " + unit.required().size()
+                                + " values, above the active limit of " + maxActiveValues
+                );
+            }
+
+            var combined = new LinkedHashSet<>(required);
+            combined.addAll(unit.required());
+            if(!keys.isEmpty() && combined.size() > maxActiveValues) {
+                batches.add(new Batch<>(keys, required));
+                keys = new ArrayList<>();
+                required = new LinkedHashSet<>();
+            }
+
+            keys.add(unit.key());
+            required.addAll(unit.required());
+        }
+        if(!keys.isEmpty())
+            batches.add(new Batch<>(keys, required));
+        return List.copyOf(batches);
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/electricity/RetryBudget.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/RetryBudget.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity;
+
+final class RetryBudget {
+    private final int maxAttempts;
+    private int attempts;
+
+    RetryBudget(int maxAttempts) {
+        if(maxAttempts <= 0)
+            throw new IllegalArgumentException("Maximum attempts must be positive");
+        this.maxAttempts = maxAttempts;
+    }
+
+    boolean tryAcquire() {
+        if(exhausted())
+            return false;
+        ++attempts;
+        return true;
+    }
+
+    boolean exhausted() {
+        return attempts >= maxAttempts;
+    }
+
+    int attempts() {
+        return attempts;
+    }
+
+    int remaining() {
+        return maxAttempts - attempts;
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/electricity/TransmissionNetworkRebuildJob.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/TransmissionNetworkRebuildJob.java
@@ -1,0 +1,757 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.FullChunkStatus;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.TicketType;
+import net.minecraft.world.level.ChunkPos;
+import org.patryk3211.powergrid.PowerGrid;
+import org.patryk3211.powergrid.electricity.sim.special.TransmissionLinePart;
+import org.patryk3211.powergrid.electricity.wire.BaseWireEntity;
+import org.patryk3211.powergrid.electricity.wire.BlockWireEndpoint;
+import org.patryk3211.powergrid.electricity.wire.IWireEndpoint;
+import org.patryk3211.powergrid.electricity.wire.JunctionWireEndpoint;
+import org.patryk3211.powergrid.electricity.wire.powercord.ICordEndpoint;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+/**
+ * Performs a verified rebuild without keeping the whole electrical network
+ * loaded at once. Each physical part is scanned with its owner and endpoint
+ * chunks active together, then all temporary tickets are released before the
+ * refreshed logical topology is assembled.
+ */
+public final class TransmissionNetworkRebuildJob {
+    static final int MAX_ACTIVE_CHUNKS = 8;
+    public static final int MAX_UNIQUE_CHUNKS = 512;
+    static final int MAX_CHUNK_LOAD_ATTEMPTS = 3;
+    static final int CHUNK_LOAD_ATTEMPT_TIMEOUT_TICKS = 100;
+    static final int CHUNK_LOAD_RETRY_DELAY_TICKS = 20;
+    static final int MAX_PHYSICAL_REGISTRATION_ATTEMPTS = 3;
+    static final int PHYSICAL_REGISTRATION_RETRY_DELAY_TICKS = 20;
+    static final int POST_ISOLATION_REGISTRATION_GRACE_TICKS = 20 * 5;
+    static final int ENTITY_REFRESH_GRACE_TICKS = WorldNetworks.ENTITY_LOAD_GRACE_TICKS + 2;
+    static final int MAX_JOB_DURATION_TICKS = 20 * 60 * 5;
+    private static final int TICKET_TIMEOUT_TICKS = CHUNK_LOAD_ATTEMPT_TIMEOUT_TICKS * 2;
+    private static final int TICKET_DISTANCE = 2;
+    private static final TicketType<ChunkPos> REBUILD_TICKET = TicketType.create(
+            "powergrid_verified_rebuild",
+            Comparator.comparingLong(ChunkPos::toLong),
+            TICKET_TIMEOUT_TICKS
+    );
+
+    public interface Listener {
+        void completed(Outcome outcome);
+
+        void failed(Failure failure);
+    }
+
+    public record StartInfo(int parts, int uniqueChunks, int batches, int maxUniqueChunks) {
+    }
+
+    public record Outcome(
+            WorldNetworks.RebuildResult rebuild,
+            int uniqueChunks,
+            int batches,
+            int verifiedParts,
+            int unresolvedParts,
+            int refreshedRecords,
+            int recoveredRecords,
+            int removedRecords,
+            long elapsedMillis
+    ) {
+        public boolean complete() {
+            return unresolvedParts == 0 && rebuild.complete();
+        }
+    }
+
+    public record Failure(String reason, Collection<ChunkPos> chunks, int attempts, long elapsedMillis) {
+        public Failure {
+            chunks = List.copyOf(chunks);
+        }
+    }
+
+    static final class TooManyChunksException extends IllegalArgumentException {
+        private final int chunks;
+
+        TooManyChunksException(int chunks) {
+            super("Verified rebuild needs " + chunks + " unique chunks, above the limit of " + MAX_UNIQUE_CHUNKS);
+            this.chunks = chunks;
+        }
+
+        int chunks() {
+            return chunks;
+        }
+    }
+
+    private record PartSnapshot(
+            TransmissionLinePart instance,
+            IWireEndpoint endpoint1,
+            IWireEndpoint endpoint2
+    ) {
+    }
+
+    private record CurrentPartEndpoints(
+            IWireEndpoint endpoint1,
+            IWireEndpoint endpoint2
+    ) {
+    }
+
+    private record Plan(
+            Map<WorldNetworks.PartId, PartSnapshot> initialParts,
+            List<RebuildBatchPlanner.Batch<WorldNetworks.PartId, ChunkPos>> batches,
+            int uniqueChunks
+    ) {
+    }
+
+    private final WorldNetworks networks;
+    private final ServerLevel world;
+    private final Listener listener;
+    private final Plan plan;
+    private final long startedAtTick;
+    private final long startedAtNanos;
+    private final Set<WorldNetworks.PartId> verifiedParts = new HashSet<>();
+    private final Set<WorldNetworks.PartId> unresolvedParts = new HashSet<>();
+    private final Set<WorldNetworks.PartId> retainedRegistrations = new HashSet<>();
+    private final Set<ChunkPos> activeTickets = new LinkedHashSet<>();
+
+    private int batchIndex = -1;
+    private RebuildBatchPlanner.Batch<WorldNetworks.PartId, ChunkPos> currentBatch;
+    private RetryBudget currentBatchBudget;
+    private RetryBudget currentRegistrationBudget;
+    private Set<WorldNetworks.PartId> pendingRegistrationIds = Set.of();
+    private long attemptStartedAt;
+    private long retryAt;
+    private long readySince = -1;
+    private long postIsolationRegistrationDeadline = -1;
+    private WorldNetworks.RebuildResult completedIsolationRebuild;
+    private boolean refreshRequested;
+    private boolean finished;
+
+    static TransmissionNetworkRebuildJob create(
+            WorldNetworks networks,
+            ServerLevel world,
+            Listener listener
+    ) {
+        return new TransmissionNetworkRebuildJob(networks, world, listener, createPlan(networks, world));
+    }
+
+    private TransmissionNetworkRebuildJob(
+            WorldNetworks networks,
+            ServerLevel world,
+            Listener listener,
+            Plan plan
+    ) {
+        this.networks = networks;
+        this.world = world;
+        this.listener = listener;
+        this.plan = plan;
+        this.startedAtTick = world.getGameTime();
+        this.startedAtNanos = System.nanoTime();
+    }
+
+    StartInfo startInfo() {
+        return new StartInfo(
+                plan.initialParts().size(),
+                plan.uniqueChunks(),
+                plan.batches().size(),
+                MAX_UNIQUE_CHUNKS
+        );
+    }
+
+    boolean isFinished() {
+        return finished;
+    }
+
+    void tick() {
+        if(finished)
+            return;
+
+        try {
+            var currentTick = world.getGameTime();
+            if(currentTick - startedAtTick > MAX_JOB_DURATION_TICKS) {
+                fail("maximum rebuild duration exceeded", activeTickets, attempts());
+                return;
+            }
+
+            if(completedIsolationRebuild != null) {
+                finishPostIsolationRegistrationCheck(currentTick);
+                return;
+            }
+
+            if(currentBatch == null) {
+                if(batchIndex + 1 >= plan.batches().size()) {
+                    finish(currentTick);
+                    return;
+                }
+                beginNextBatch(currentTick);
+                return;
+            }
+
+            if(currentTick < retryAt)
+                return;
+
+            if(activeTickets.isEmpty()) {
+                beginAttempt(currentTick);
+                return;
+            }
+
+            if(allChunksReady()) {
+                if(!refreshRequested) {
+                    if(!currentRegistrationBudget.tryAcquire()) {
+                        finishOrScheduleRegistrationRetry(currentTick);
+                        return;
+                    }
+                    refreshPhysicalOwnerRegistrations(pendingRegistrationIds);
+                    refreshRequested = true;
+                    readySince = currentTick;
+                    return;
+                }
+                if(currentTick - readySince < ENTITY_REFRESH_GRACE_TICKS)
+                    return;
+
+                finishOrScheduleRegistrationRetry(currentTick);
+                return;
+            }
+
+            readySince = -1;
+            refreshRequested = false;
+            if(currentTick - attemptStartedAt < CHUNK_LOAD_ATTEMPT_TIMEOUT_TICKS)
+                return;
+
+            var exhausted = currentBatchBudget.exhausted();
+            releaseActiveTickets();
+            if(exhausted) {
+                fail(
+                        "chunk batch did not reach entity-ticking state",
+                        currentBatch.required(),
+                        currentBatchBudget.attempts()
+                );
+            } else {
+                retryAt = currentTick + CHUNK_LOAD_RETRY_DELAY_TICKS;
+            }
+        } catch(RuntimeException exception) {
+            PowerGrid.LOGGER.error(
+                    "Verified transmission rebuild crashed in {}",
+                    world.dimension().location(),
+                    exception
+            );
+            fail("unexpected rebuild exception: " + exception.getClass().getSimpleName(), activeTickets, attempts());
+        }
+    }
+
+    void cancel() {
+        releaseActiveTickets();
+        networks.abortVerifiedRebuildIsolation();
+        finished = true;
+    }
+
+    private void beginNextBatch(long currentTick) {
+        currentBatch = plan.batches().get(++batchIndex);
+        currentBatchBudget = new RetryBudget(MAX_CHUNK_LOAD_ATTEMPTS);
+        currentRegistrationBudget = new RetryBudget(MAX_PHYSICAL_REGISTRATION_ATTEMPTS);
+        pendingRegistrationIds = Set.copyOf(currentBatch.keys());
+        retryAt = currentTick;
+        beginAttempt(currentTick);
+    }
+
+    private void beginAttempt(long currentTick) {
+        if(!currentBatchBudget.tryAcquire()) {
+            fail("chunk retry budget exhausted", currentBatch.required(), currentBatchBudget.attempts());
+            return;
+        }
+
+        attemptStartedAt = currentTick;
+        readySince = -1;
+        refreshRequested = false;
+        for(var chunk : currentBatch.required()) {
+            world.getChunkSource().addRegionTicket(
+                    REBUILD_TICKET,
+                    chunk,
+                    TICKET_DISTANCE,
+                    chunk
+            );
+            activeTickets.add(chunk);
+        }
+        PowerGrid.LOGGER.info(
+                "Verified transmission rebuild in {} loading batch {}/{}: {} chunks, attempt {}/{}",
+                world.dimension().location(),
+                batchIndex + 1,
+                plan.batches().size(),
+                activeTickets.size(),
+                currentBatchBudget.attempts(),
+                MAX_CHUNK_LOAD_ATTEMPTS
+        );
+    }
+
+    private boolean allChunksReady() {
+        for(var chunkPos : activeTickets) {
+            var chunk = world.getChunkSource().getChunkNow(chunkPos.x, chunkPos.z);
+            if(chunk == null
+                    || chunk.getFullStatus() != FullChunkStatus.ENTITY_TICKING
+                    || !world.areEntitiesLoaded(chunkPos.toLong())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void refreshPhysicalOwnerRegistrations(Collection<WorldNetworks.PartId> ids) {
+        var refreshedEntities = new HashMap<java.util.UUID, BaseWireEntity>();
+        var readyIds = new HashSet<WorldNetworks.PartId>();
+        for(var id : ids) {
+            var owner = id.getEntity(world);
+            if(owner != null && physicalOwnerReady(owner)) {
+                refreshedEntities.putIfAbsent(owner.getUUID(), owner);
+                readyIds.add(id);
+            }
+        }
+
+        // Do not remove a persisted registration while the physical entity's
+        // endpoints are still attaching their block behaviours. Startup can
+        // load a wire entity before one of those late behaviours exists.
+        // Ready owners remain authoritative and are refreshed normally.
+        for(var owner : refreshedEntities.values())
+            owner.dropWire();
+        for(var id : readyIds) {
+            var owner = id.getEntity(world);
+            if(owner != null)
+                networks.removePartForVerifiedRefresh(id, owner);
+        }
+        for(var owner : refreshedEntities.values())
+            owner.makeWire();
+    }
+
+    private boolean physicalOwnerReady(BaseWireEntity owner) {
+        var endpoint1 = owner.getEndpoint1();
+        var endpoint2 = owner.getEndpoint2();
+        var endpoint1Valid = endpoint1 != null && endpoint1.isValid(world);
+        var endpoint2Valid = endpoint2 != null && endpoint2.isValid(world);
+        return registrationReady(
+                !owner.isRemoved(),
+                endpoint1 != null,
+                endpoint1Valid,
+                endpoint2 != null,
+                endpoint2Valid
+        );
+    }
+
+    static boolean registrationReady(
+            boolean ownerLoaded,
+            boolean endpoint1Present,
+            boolean endpoint1Valid,
+            boolean endpoint2Present,
+            boolean endpoint2Valid
+    ) {
+        return ownerLoaded
+                && endpoint1Present
+                && endpoint1Valid
+                && endpoint2Present
+                && endpoint2Valid;
+    }
+
+    static boolean canRetainPersistedRegistration(
+            boolean ownerLoaded,
+            boolean partPresent,
+            boolean endpointsMatch,
+            boolean endpoint1StructurallyValid,
+            boolean endpoint2StructurallyValid
+    ) {
+        return ownerLoaded
+                && partPresent
+                && endpointsMatch
+                && endpoint1StructurallyValid
+                && endpoint2StructurallyValid;
+    }
+
+    private Set<WorldNetworks.PartId> verifyCurrentBatch() {
+        var attemptUnresolved = new HashSet<WorldNetworks.PartId>();
+        for(var id : currentBatch.keys()) {
+            var owner = id.getEntity(world);
+            var part = networks.getPart(id);
+            if(owner != null && part != null && part.owner == owner) {
+                verifiedParts.add(id);
+                unresolvedParts.remove(id);
+            } else if(owner == null) {
+                networks.removeStalePartAfterVerifiedScan(id);
+                unresolvedParts.remove(id);
+            } else if(retainPersistedRegistration(id, owner, part)) {
+                verifiedParts.add(id);
+                unresolvedParts.remove(id);
+            } else {
+                unresolvedParts.add(id);
+                attemptUnresolved.add(id);
+            }
+        }
+        return Set.copyOf(attemptUnresolved);
+    }
+
+    private boolean retainPersistedRegistration(
+            WorldNetworks.PartId id,
+            BaseWireEntity owner,
+            TransmissionLinePart part
+    ) {
+        var currentEndpoints = currentPartEndpoints(owner, id);
+        var endpoint1 = currentEndpoints.endpoint1();
+        var endpoint2 = currentEndpoints.endpoint2();
+        var endpointsMatch = part != null
+                && endpoint1 != null
+                && endpoint2 != null
+                && part.endpointsMatch(endpoint1, endpoint2);
+        var endpoint1StructurallyValid =
+                endpoint1 != null && endpoint1.isStructurallyValid(world);
+        var endpoint2StructurallyValid =
+                endpoint2 != null && endpoint2.isStructurallyValid(world);
+        if(!canRetainPersistedRegistration(
+                !owner.isRemoved(),
+                part != null,
+                endpointsMatch,
+                endpoint1StructurallyValid,
+                endpoint2StructurallyValid
+        )) {
+            return false;
+        }
+        if(!part.grab(owner, id))
+            return false;
+
+        if(retainedRegistrations.add(id)) {
+            PowerGrid.LOGGER.info(
+                    "Verified transmission rebuild in {} retained persisted registration {} after physical endpoint validation: ({}, {}), runtimeEndpoint1Ready={}, runtimeEndpoint2Ready={}",
+                    world.dimension().location(),
+                    id,
+                    endpoint1,
+                    endpoint2,
+                    endpoint1.isValid(world),
+                    endpoint2.isValid(world)
+            );
+        }
+        return true;
+    }
+
+    private static CurrentPartEndpoints currentPartEndpoints(
+            BaseWireEntity owner,
+            WorldNetworks.PartId id
+    ) {
+        return new CurrentPartEndpoints(
+                connectionEndpointForPart(owner.getEndpoint1(), id),
+                connectionEndpointForPart(owner.getEndpoint2(), id)
+        );
+    }
+
+    static IWireEndpoint connectionEndpointForPart(
+            IWireEndpoint ownerEndpoint,
+            WorldNetworks.PartId id
+    ) {
+        if(id instanceof WorldNetworks.ComplexId complexId) {
+            if(!(ownerEndpoint instanceof ICordEndpoint cordEndpoint))
+                return null;
+            return switch(complexId.sub()) {
+                case 0 -> cordEndpoint.getEndpoint1();
+                case 1 -> cordEndpoint.getEndpoint2();
+                default -> null;
+            };
+        }
+        return ownerEndpoint;
+    }
+
+    private void finishOrScheduleRegistrationRetry(long currentTick) {
+        var attemptUnresolved = verifyCurrentBatch();
+        if(!attemptUnresolved.isEmpty() && !currentRegistrationBudget.exhausted()) {
+            pendingRegistrationIds = attemptUnresolved;
+            refreshRequested = false;
+            readySince = -1;
+            retryAt = currentTick + PHYSICAL_REGISTRATION_RETRY_DELAY_TICKS;
+            PowerGrid.LOGGER.warn(
+                    "Verified transmission rebuild in {} will retry {} unresolved physical registrations from batch {}/{}; next attempt {}/{}",
+                    world.dimension().location(),
+                    attemptUnresolved.size(),
+                    batchIndex + 1,
+                    plan.batches().size(),
+                    currentRegistrationBudget.attempts() + 1,
+                    MAX_PHYSICAL_REGISTRATION_ATTEMPTS
+            );
+            return;
+        }
+
+        if(!attemptUnresolved.isEmpty()) {
+            logExhaustedPhysicalRegistrations(attemptUnresolved);
+            removeUnverifiedPhysicalRegistrations(attemptUnresolved);
+        }
+        releaseActiveTickets();
+        currentBatch = null;
+        pendingRegistrationIds = Set.of();
+    }
+
+    private void removeUnverifiedPhysicalRegistrations(Set<WorldNetworks.PartId> ids) {
+        for(var id : ids) {
+            var owner = id.getEntity(world);
+            if(owner != null)
+                networks.removePartForVerifiedRefresh(id, owner);
+        }
+    }
+
+    private void logExhaustedPhysicalRegistrations(Set<WorldNetworks.PartId> ids) {
+        for(var id : ids) {
+            var owner = id.getEntity(world);
+            var initial = plan.initialParts().get(id);
+            var currentEndpoints = owner != null
+                    ? currentPartEndpoints(owner, id)
+                    : new CurrentPartEndpoints(null, null);
+            var currentEndpoint1 = currentEndpoints.endpoint1();
+            var currentEndpoint2 = currentEndpoints.endpoint2();
+            var currentEndpoint1Valid = currentEndpoint1 != null && currentEndpoint1.isValid(world);
+            var currentEndpoint2Valid = currentEndpoint2 != null && currentEndpoint2.isValid(world);
+            var currentEndpoint1StructurallyValid =
+                    currentEndpoint1 != null && currentEndpoint1.isStructurallyValid(world);
+            var currentEndpoint2StructurallyValid =
+                    currentEndpoint2 != null && currentEndpoint2.isStructurallyValid(world);
+            PowerGrid.LOGGER.warn(
+                    "Physical transmission registration {} remains unresolved after {}/{} attempts in {} "
+                            + "(ownerLoaded={}, ownerType={}, ownerPos={}, currentEndpoint1={}, currentEndpoint1Valid={}, currentEndpoint1StructurallyValid={}, "
+                            + "currentEndpoint2={}, currentEndpoint2Valid={}, currentEndpoint2StructurallyValid={}, savedEndpoint1={}, savedEndpoint2={})",
+                    id,
+                    currentRegistrationBudget.attempts(),
+                    MAX_PHYSICAL_REGISTRATION_ATTEMPTS,
+                    world.dimension().location(),
+                    owner != null && !owner.isRemoved(),
+                    owner != null ? owner.getType() : null,
+                    owner != null ? owner.blockPosition() : null,
+                    currentEndpoint1,
+                    currentEndpoint1Valid,
+                    currentEndpoint1StructurallyValid,
+                    currentEndpoint2,
+                    currentEndpoint2Valid,
+                    currentEndpoint2StructurallyValid,
+                    initial != null ? initial.endpoint1() : null,
+                    initial != null ? initial.endpoint2() : null
+            );
+        }
+    }
+
+    private void finish(long currentTick) {
+        releaseActiveTickets();
+        completedIsolationRebuild = networks.completeVerifiedRebuildIsolation();
+        if(!unresolvedParts.isEmpty()) {
+            postIsolationRegistrationDeadline =
+                    currentTick + POST_ISOLATION_REGISTRATION_GRACE_TICKS;
+            PowerGrid.LOGGER.info(
+                    "Verified transmission rebuild in {} opened a {}-tick post-isolation settlement window for {} late physical registrations; no additional rebuild attempts will be made",
+                    world.dimension().location(),
+                    POST_ISOLATION_REGISTRATION_GRACE_TICKS,
+                    unresolvedParts.size()
+            );
+            return;
+        }
+        completeOutcome(completedIsolationRebuild);
+    }
+
+    private void finishPostIsolationRegistrationCheck(long currentTick) {
+        var recovered = reconcileRecoveredRegistrations(
+                unresolvedParts,
+                verifiedParts,
+                id -> {
+                    var owner = id.getEntity(world);
+                    var part = networks.getPart(id);
+                    return part != null && (owner == null || part.owner == owner);
+                }
+        );
+        if(recovered > 0) {
+            PowerGrid.LOGGER.info(
+                    "Verified transmission rebuild in {} observed {} late physical registrations after topology isolation ended; {} remain unresolved",
+                    world.dimension().location(),
+                    recovered,
+                    unresolvedParts.size()
+            );
+        }
+        if(unresolvedParts.isEmpty() || currentTick >= postIsolationRegistrationDeadline)
+            completeOutcome(networks.refreshVerifiedRebuildResult(completedIsolationRebuild));
+    }
+
+    static <T> int reconcileRecoveredRegistrations(
+            Set<T> unresolved,
+            Set<T> verified,
+            Predicate<T> registered
+    ) {
+        int recovered = 0;
+        var iterator = unresolved.iterator();
+        while(iterator.hasNext()) {
+            var id = iterator.next();
+            if(!registered.test(id))
+                continue;
+            iterator.remove();
+            verified.add(id);
+            ++recovered;
+        }
+        return recovered;
+    }
+
+    private void completeOutcome(WorldNetworks.RebuildResult rebuild) {
+        var currentParts = networks.linePartsSnapshot();
+        int refreshedRecords = 0;
+        int removedRecords = 0;
+        for(var entry : plan.initialParts().entrySet()) {
+            var current = currentParts.get(entry.getKey());
+            if(current == null) {
+                ++removedRecords;
+                continue;
+            }
+            var initial = entry.getValue();
+            if(current != initial.instance()
+                    || !TransmissionLinePart.sameEndpoints(
+                            initial.endpoint1(),
+                            initial.endpoint2(),
+                            current.getConnectionEndpoint1(),
+                            current.getConnectionEndpoint2()
+                    )) {
+                ++refreshedRecords;
+            }
+        }
+        int recoveredRecords = 0;
+        for(var id : currentParts.keySet()) {
+            if(!plan.initialParts().containsKey(id))
+                ++recoveredRecords;
+        }
+
+        var elapsedMillis = elapsedMillis();
+        var outcome = new Outcome(
+                rebuild,
+                plan.uniqueChunks(),
+                plan.batches().size(),
+                verifiedParts.size(),
+                unresolvedParts.size(),
+                refreshedRecords,
+                recoveredRecords,
+                removedRecords,
+                elapsedMillis
+        );
+        PowerGrid.LOGGER.info(
+                "Verified transmission rebuild completed in {}: {} unique chunks, {} batches, {} parts verified, {} unresolved parts, {} persisted registrations retained after structural validation, {} records refreshed, {} recovered, {} removed, {} ms",
+                world.dimension().location(),
+                outcome.uniqueChunks(),
+                outcome.batches(),
+                outcome.verifiedParts(),
+                outcome.unresolvedParts(),
+                retainedRegistrations.size(),
+                outcome.refreshedRecords(),
+                outcome.recoveredRecords(),
+                outcome.removedRecords(),
+                outcome.elapsedMillis()
+        );
+        finished = true;
+        listener.completed(outcome);
+    }
+
+    private void fail(String reason, Collection<ChunkPos> chunks, int attempts) {
+        if(finished)
+            return;
+        var failedChunks = List.copyOf(chunks);
+        releaseActiveTickets();
+        networks.abortVerifiedRebuildIsolation();
+        var failure = new Failure(reason, failedChunks, attempts, elapsedMillis());
+        PowerGrid.LOGGER.error(
+                "Verified transmission rebuild failed in {} after {} attempts and {} ms: {}; chunks={}",
+                world.dimension().location(),
+                attempts,
+                failure.elapsedMillis(),
+                reason,
+                failure.chunks()
+        );
+        finished = true;
+        listener.failed(failure);
+    }
+
+    private int attempts() {
+        return currentBatchBudget == null ? 0 : currentBatchBudget.attempts();
+    }
+
+    private long elapsedMillis() {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos);
+    }
+
+    private void releaseActiveTickets() {
+        for(var chunk : activeTickets) {
+            world.getChunkSource().removeRegionTicket(
+                    REBUILD_TICKET,
+                    chunk,
+                    TICKET_DISTANCE,
+                    chunk
+            );
+        }
+        activeTickets.clear();
+    }
+
+    private static Plan createPlan(WorldNetworks networks, ServerLevel world) {
+        var initial = networks.linePartsSnapshot();
+        var ordered = new ArrayList<>(initial.entrySet());
+        ordered.sort(Comparator.comparing(entry -> entry.getKey().toString()));
+
+        var snapshots = new HashMap<WorldNetworks.PartId, PartSnapshot>();
+        var units = new ArrayList<RebuildBatchPlanner.Unit<WorldNetworks.PartId, ChunkPos>>();
+        var uniqueChunks = new LinkedHashSet<ChunkPos>();
+        for(var entry : ordered) {
+            var id = entry.getKey();
+            var part = entry.getValue();
+            snapshots.put(
+                    id,
+                    new PartSnapshot(
+                            part,
+                            part.getConnectionEndpoint1(),
+                            part.getConnectionEndpoint2()
+                    )
+            );
+
+            var required = requiredChunks(part, world);
+            units.add(new RebuildBatchPlanner.Unit<>(id, required));
+            uniqueChunks.addAll(required);
+        }
+
+        if(uniqueChunks.size() > MAX_UNIQUE_CHUNKS)
+            throw new TooManyChunksException(uniqueChunks.size());
+
+        var batches = RebuildBatchPlanner.plan(units, MAX_ACTIVE_CHUNKS);
+        return new Plan(Map.copyOf(snapshots), batches, uniqueChunks.size());
+    }
+
+    private static Set<ChunkPos> requiredChunks(TransmissionLinePart part, ServerLevel world) {
+        var required = new LinkedHashSet<ChunkPos>();
+        required.add(part.lastKnownChunk);
+        if(part.owner != null && !part.owner.isRemoved())
+            required.add(new ChunkPos(part.owner.blockPosition()));
+        addEndpointChunk(required, part.getConnectionEndpoint1(), world);
+        addEndpointChunk(required, part.getConnectionEndpoint2(), world);
+        return Set.copyOf(required);
+    }
+
+    private static void addEndpointChunk(Set<ChunkPos> chunks, IWireEndpoint endpoint, ServerLevel world) {
+        if(endpoint instanceof BlockWireEndpoint block) {
+            chunks.add(new ChunkPos(block.getPos()));
+        } else if(endpoint instanceof JunctionWireEndpoint junction) {
+            chunks.add(new ChunkPos(BlockPos.containing(junction.getExactPosition(world))));
+        }
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/electricity/WorldNetworks.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/WorldNetworks.java
@@ -53,6 +53,9 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
     static final int MAX_AUTOMATIC_REBUILD_RETRIES = 3;
     static final int REBUILD_RETRY_INTERVAL_TICKS = 20;
     static final int MAX_REBUILD_RETRIES_PER_TICK = 16;
+    static final int MAX_INCREMENTAL_RESOLUTION_RETRIES = 3;
+    static final int INCREMENTAL_RESOLUTION_RETRY_INTERVAL_TICKS = 20;
+    static final int MAX_INCREMENTAL_RESOLUTION_RETRIES_PER_TICK = 16;
 
     enum TransmissionPartSide {
         FIRST,
@@ -82,7 +85,10 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
     protected final Set<TransmissionLinePart> deferredRewireEntities = new HashSet<>();
     protected final Set<ElectricalNetwork> islandDiscoveryQueue = new HashSet<>();
+    private final Set<ElectricalNetwork> deferredIslandDiscoveryQueue = new HashSet<>();
     private final Map<PartId, RebuildRetry> rebuildRetryQueue = new HashMap<>();
+    private final Map<PartId, IncrementalResolutionRetry> incrementalResolutionRetryQueue =
+            new HashMap<>();
     private TransmissionNetworkRebuildJob verifiedRebuildJob;
     private boolean startupRebuildStarted;
     private boolean verifiedRebuildIsolated;
@@ -121,6 +127,17 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         private long nextAttemptTick;
 
         private RebuildRetry(TransmissionLinePart part, long nextAttemptTick) {
+            this.part = part;
+            this.nextAttemptTick = nextAttemptTick;
+        }
+    }
+
+    private static class IncrementalResolutionRetry {
+        private final TransmissionLinePart part;
+        private final RetryBudget budget = new RetryBudget(MAX_INCREMENTAL_RESOLUTION_RETRIES);
+        private long nextAttemptTick;
+
+        private IncrementalResolutionRetry(TransmissionLinePart part, long nextAttemptTick) {
             this.part = part;
             this.nextAttemptTick = nextAttemptTick;
         }
@@ -181,8 +198,23 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
     }
 
     public void scheduleIslandDiscovery(ElectricalNetwork network) {
-        if(network != null && !runningDiscovery && !verifiedRebuildIsolated)
-            islandDiscoveryQueue.add(network);
+        if(network == null || verifiedRebuildIsolated)
+            return;
+        enqueueIslandDiscovery(
+                network,
+                runningDiscovery,
+                islandDiscoveryQueue,
+                deferredIslandDiscoveryQueue
+        );
+    }
+
+    static <T> void enqueueIslandDiscovery(
+            @NotNull T network,
+            boolean runningDiscovery,
+            Set<T> currentQueue,
+            Set<T> deferredQueue
+    ) {
+        (runningDiscovery ? deferredQueue : currentQueue).add(network);
     }
 
     private void runIslandDiscoveryFor(ElectricalNetwork network) {
@@ -313,16 +345,24 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
             // register itself, but no partially rebuilt transmission topology
             // may enter island discovery or the electrical solver.
             islandDiscoveryQueue.clear();
+            deferredIslandDiscoveryQueue.clear();
             return;
         }
         processRebuildRetries();
+        processIncrementalResolutionRetries();
 
-        runningDiscovery = true;
-        for(var network : islandDiscoveryQueue) {
-            runIslandDiscoveryFor(network);
-        }
+        var discoveryBatch = List.copyOf(islandDiscoveryQueue);
         islandDiscoveryQueue.clear();
-        runningDiscovery = false;
+        runningDiscovery = true;
+        try {
+            for(var network : discoveryBatch) {
+                runIslandDiscoveryFor(network);
+            }
+        } finally {
+            runningDiscovery = false;
+            islandDiscoveryQueue.addAll(deferredIslandDiscoveryQueue);
+            deferredIslandDiscoveryQueue.clear();
+        }
 
         var iter2 = transmissionLines.values().iterator();
         var removed = new ArrayList<TransmissionLine>();
@@ -977,6 +1017,26 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         return true;
     }
 
+    private boolean resolveIncrementalTransmissionPart(TransmissionLinePart linePart) {
+        var resolved = makeTransmissionLine(linePart);
+        retainRegisteredPartWhileResolving(
+                linePart,
+                resolved,
+                this::scheduleIncrementalResolutionRetry
+        );
+        return resolved;
+    }
+
+    static <T> T retainRegisteredPartWhileResolving(
+            @NotNull T part,
+            boolean resolved,
+            java.util.function.Consumer<T> retryScheduler
+    ) {
+        if(!resolved)
+            retryScheduler.accept(part);
+        return part;
+    }
+
     @Nullable
     public ElectricWire makeSimpleWire(IWireEndpoint endpoint1, IWireEndpoint endpoint2, float resistance) {
         var network = prepareForConnection(endpoint1, endpoint2);
@@ -1008,9 +1068,11 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         if(linePart == null)
             linePart = TransmissionLinePart.uniquePart(forEntity.getResistance(), endpoint1, endpoint2, forEntity, this, id);
 
-        if(makeTransmissionLine(linePart))
-            return linePart;
-        return null;
+        resolveIncrementalTransmissionPart(linePart);
+        // Keep the physical owner linked to its persisted registration even if
+        // endpoint initialization requires a bounded deferred resolution. This
+        // lets removal, unload and the retry path continue to manage the part.
+        return linePart;
     }
 
     @Nullable
@@ -1085,6 +1147,7 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
             throw new IllegalStateException("Transmission networks can only be rebuilt on the server");
 
         rebuildRetryQueue.clear();
+        incrementalResolutionRetryQueue.clear();
         var parts = new ArrayList<>(lineParts.values());
         parts.sort(Comparator.comparing(part -> part.persistentOwnerId.toString()));
 
@@ -1164,7 +1227,9 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
         verifiedRebuildIsolated = true;
         islandDiscoveryQueue.clear();
+        deferredIslandDiscoveryQueue.clear();
         rebuildRetryQueue.clear();
+        incrementalResolutionRetryQueue.clear();
         try {
             verifiedRebuildLinesBefore = detachDerivedTransmissionTopology();
         } catch(RuntimeException exception) {
@@ -1220,7 +1285,123 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
     private void scheduleDiscoveryForAllNetworks() {
         islandDiscoveryQueue.clear();
+        deferredIslandDiscoveryQueue.clear();
         islandDiscoveryQueue.addAll(subnetworks);
+    }
+
+    private void scheduleIncrementalResolutionRetry(TransmissionLinePart part) {
+        if(verifiedRebuildIsolated || assemblingTransmissionTopology)
+            return;
+        incrementalResolutionRetryQueue.computeIfAbsent(
+                part.persistentOwnerId,
+                $ -> {
+                    PowerGrid.LOGGER.warn(
+                            "Deferred incremental transmission attachment {} in {} because its endpoint nodes are not ready; retrying at most {} times",
+                            part.persistentOwnerId,
+                            world.dimension().location(),
+                            MAX_INCREMENTAL_RESOLUTION_RETRIES
+                    );
+                    return new IncrementalResolutionRetry(
+                            part,
+                            world.getGameTime() + INCREMENTAL_RESOLUTION_RETRY_INTERVAL_TICKS
+                    );
+                }
+        );
+    }
+
+    private void processIncrementalResolutionRetries() {
+        if(incrementalResolutionRetryQueue.isEmpty())
+            return;
+
+        var currentTick = world.getGameTime();
+        int attemptsThisTick = 0;
+        var iterator = incrementalResolutionRetryQueue.entrySet().iterator();
+        while(iterator.hasNext()
+                && attemptsThisTick < MAX_INCREMENTAL_RESOLUTION_RETRIES_PER_TICK) {
+            var entry = iterator.next();
+            var retry = entry.getValue();
+            var part = retry.part;
+
+            if(lineParts.get(entry.getKey()) != part) {
+                iterator.remove();
+                continue;
+            }
+            if(part.getLine() != null) {
+                iterator.remove();
+                continue;
+            }
+            if(currentTick < retry.nextAttemptTick)
+                continue;
+            if(!retry.budget.tryAcquire()) {
+                iterator.remove();
+                continue;
+            }
+
+            ++attemptsThisTick;
+            restorePartEndpointNodes(part);
+            try {
+                if(makeTransmissionLine(part)) {
+                    PowerGrid.LOGGER.info(
+                            "Incremental transmission attachment {} resolved automatically on retry {}/{} in {}",
+                            part.persistentOwnerId,
+                            retry.budget.attempts(),
+                            MAX_INCREMENTAL_RESOLUTION_RETRIES,
+                            world.dimension().location()
+                    );
+                    iterator.remove();
+                    continue;
+                }
+                logIncrementalResolutionFailure(part, retry.budget, null);
+            } catch(RuntimeException exception) {
+                logIncrementalResolutionFailure(part, retry.budget, exception);
+            }
+
+            if(retry.budget.exhausted()) {
+                iterator.remove();
+            } else {
+                retry.nextAttemptTick =
+                        currentTick + INCREMENTAL_RESOLUTION_RETRY_INTERVAL_TICKS;
+            }
+        }
+    }
+
+    private void logIncrementalResolutionFailure(
+            TransmissionLinePart part,
+            RetryBudget budget,
+            @Nullable RuntimeException exception
+    ) {
+        var state = budget.exhausted() ? "retry limit exhausted" : "retry pending";
+        var message =
+                "Failed incremental transmission attachment {} on retry {}/{} in {} "
+                        + "({}; endpoint1={}, endpoint2={}, node1={}, node2={})";
+        if(exception == null) {
+            PowerGrid.LOGGER.warn(
+                    message,
+                    part.persistentOwnerId,
+                    budget.attempts(),
+                    MAX_INCREMENTAL_RESOLUTION_RETRIES,
+                    world.dimension().location(),
+                    state,
+                    part.getConnectionEndpoint1(),
+                    part.getConnectionEndpoint2(),
+                    part.getNode1(),
+                    part.getNode2()
+            );
+        } else {
+            PowerGrid.LOGGER.error(
+                    message,
+                    part.persistentOwnerId,
+                    budget.attempts(),
+                    MAX_INCREMENTAL_RESOLUTION_RETRIES,
+                    world.dimension().location(),
+                    state,
+                    part.getConnectionEndpoint1(),
+                    part.getConnectionEndpoint2(),
+                    part.getNode1(),
+                    part.getNode2(),
+                    exception
+            );
+        }
     }
 
     private void scheduleRebuildRetry(TransmissionLinePart part) {
@@ -1430,14 +1611,14 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
                     // Check endpoint2
                     if(part.getConnectionEndpoint2().isValid(world)) {
                         // Resolve segment
-                        makeTransmissionLine(part);
+                        resolveIncrementalTransmissionPart(part);
                         return true;
                     }
                 } else if(side == TransmissionPartSide.SECOND) {
                     // Check endpoint1
                     if(part.getConnectionEndpoint1().isValid(world)) {
                         // Resolve segment
-                        makeTransmissionLine(part);
+                        resolveIncrementalTransmissionPart(part);
                         return true;
                     }
                 } else {
@@ -1455,12 +1636,12 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
                 PowerGrid.LOGGER.debug("Continuing line trace through {}", endpointNode);
             if(side == TransmissionPartSide.FIRST) {
                 if(traceTree(part.getNode2(), visited)) {
-                    makeTransmissionLine(part);
+                    resolveIncrementalTransmissionPart(part);
                     continueResolving = true;
                 }
             } else if(side == TransmissionPartSide.SECOND) {
                 if(traceTree(part.getNode1(), visited)) {
-                    makeTransmissionLine(part);
+                    resolveIncrementalTransmissionPart(part);
                     continueResolving = true;
                 }
             } else {

--- a/src/main/java/org/patryk3211/powergrid/electricity/WorldNetworks.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/WorldNetworks.java
@@ -17,6 +17,7 @@ package org.patryk3211.powergrid.electricity;
 
 import com.google.common.collect.Sets;
 import io.netty.util.collection.IntObjectHashMap;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -48,6 +49,22 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModifyHooks {
+    static final int ENTITY_LOAD_GRACE_TICKS = 10;
+    static final int MAX_AUTOMATIC_REBUILD_RETRIES = 3;
+    static final int REBUILD_RETRY_INTERVAL_TICKS = 20;
+    static final int MAX_REBUILD_RETRIES_PER_TICK = 16;
+
+    enum TransmissionPartSide {
+        FIRST,
+        SECOND,
+        NONE
+    }
+
+    enum NodeBindingMode {
+        BIND_ONLY,
+        BIND_AND_SPLIT
+    }
+
     public final Level world;
     public final NetworkGraph globalGraph = new NetworkGraph();
     protected final PerformanceCounter perf;
@@ -65,6 +82,12 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
     protected final Set<TransmissionLinePart> deferredRewireEntities = new HashSet<>();
     protected final Set<ElectricalNetwork> islandDiscoveryQueue = new HashSet<>();
+    private final Map<PartId, RebuildRetry> rebuildRetryQueue = new HashMap<>();
+    private TransmissionNetworkRebuildJob verifiedRebuildJob;
+    private boolean startupRebuildStarted;
+    private boolean verifiedRebuildIsolated;
+    private boolean assemblingTransmissionTopology;
+    private int verifiedRebuildLinesBefore;
     private boolean runningDiscovery = false;
     private int syncTicks = 0;
 
@@ -72,6 +95,36 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
     private record SyncState(int lod) { }
     private final Map<ServerPlayer, Map<ISynchronizedElement, SyncState>> syncStates = new HashMap<>();
+
+    public record RebuildResult(int parts, int linesBefore, int linesAfter, int retryingParts, int retryLimit) {
+        public boolean complete() {
+            return retryingParts == 0;
+        }
+    }
+
+    public enum VerifiedRebuildStartStatus {
+        STARTED,
+        ALREADY_RUNNING,
+        TOO_MANY_CHUNKS
+    }
+
+    public record VerifiedRebuildStart(
+            VerifiedRebuildStartStatus status,
+            @Nullable TransmissionNetworkRebuildJob.StartInfo info,
+            int requestedChunks
+    ) {
+    }
+
+    private static class RebuildRetry {
+        private final TransmissionLinePart part;
+        private final RetryBudget budget = new RetryBudget(MAX_AUTOMATIC_REBUILD_RETRIES);
+        private long nextAttemptTick;
+
+        private RebuildRetry(TransmissionLinePart part, long nextAttemptTick) {
+            this.part = part;
+            this.nextAttemptTick = nextAttemptTick;
+        }
+    }
 
     public WorldNetworks(Level world) {
         this.world = world;
@@ -93,17 +146,25 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
     @Override
     public void lineConnected(TransmissionLine line) {
+        var node1 = Objects.requireNonNull(
+                line.getNode1(),
+                "Transmission lines cannot connect without a first node"
+        );
+        var node2 = Objects.requireNonNull(
+                line.getNode2(),
+                "Transmission lines cannot connect without a second node"
+        );
         var id = line.getId();
         transmissionLines.put(id, line);
 
-        var line1 = findLineMiddle(line.getNode1());
+        var line1 = findLineMiddle(node1);
         if(line1 != null)
-            line1.splitAt(line.getNode1());
-        var line2 = findLineMiddle(line.getNode2());
+            line1.splitAt(node1);
+        var line2 = findLineMiddle(node2);
         if(line2 != null)
-            line2.splitAt(line.getNode2());
-        scheduleIslandDiscovery(line.getNode1().getNetwork());
-        scheduleIslandDiscovery(line.getNode2().getNetwork());
+            line2.splitAt(node2);
+        scheduleIslandDiscovery(node1.getNetwork());
+        scheduleIslandDiscovery(node2.getNetwork());
         setDirty();
     }
 
@@ -120,7 +181,7 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
     }
 
     public void scheduleIslandDiscovery(ElectricalNetwork network) {
-        if(network != null && !runningDiscovery)
+        if(network != null && !runningDiscovery && !verifiedRebuildIsolated)
             islandDiscoveryQueue.add(network);
     }
 
@@ -238,11 +299,23 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
     }
 
     public void preTick() {
-        deferredRewireEntities.removeIf(part -> {
-            part.refreshEndpointNodes();
-            return true;
-        });
+        if(!verifiedRebuildIsolated) {
+            deferredRewireEntities.removeIf(part -> {
+                part.refreshEndpointNodes();
+                return true;
+            });
+        }
         JunctionWireEndpoint.processNewNodes(world);
+        startStartupRebuildIfNeeded();
+        tickVerifiedRebuild();
+        if(verifiedRebuildIsolated) {
+            // Physical entities keep ticking so the current chunk batch can
+            // register itself, but no partially rebuilt transmission topology
+            // may enter island discovery or the electrical solver.
+            islandDiscoveryQueue.clear();
+            return;
+        }
+        processRebuildRetries();
 
         runningDiscovery = true;
         for(var network : islandDiscoveryQueue) {
@@ -286,7 +359,107 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         perf.end();
     }
 
+    public boolean verifiedRebuildInProgress() {
+        return verifiedRebuildJob != null && !verifiedRebuildJob.isFinished();
+    }
+
+    public VerifiedRebuildStart startVerifiedRebuild(TransmissionNetworkRebuildJob.Listener listener) {
+        if(!(world instanceof ServerLevel serverWorld))
+            throw new IllegalStateException("Verified rebuilds require a server level");
+        if(verifiedRebuildInProgress()) {
+            return new VerifiedRebuildStart(
+                    VerifiedRebuildStartStatus.ALREADY_RUNNING,
+                    verifiedRebuildJob.startInfo(),
+                    verifiedRebuildJob.startInfo().uniqueChunks()
+            );
+        }
+
+        rebuildRetryQueue.clear();
+        try {
+            var job = TransmissionNetworkRebuildJob.create(this, serverWorld, listener);
+            beginVerifiedRebuildIsolation();
+            verifiedRebuildJob = job;
+            return new VerifiedRebuildStart(
+                    VerifiedRebuildStartStatus.STARTED,
+                    verifiedRebuildJob.startInfo(),
+                    verifiedRebuildJob.startInfo().uniqueChunks()
+            );
+        } catch(TransmissionNetworkRebuildJob.TooManyChunksException exception) {
+            return new VerifiedRebuildStart(
+                    VerifiedRebuildStartStatus.TOO_MANY_CHUNKS,
+                    null,
+                    exception.chunks()
+            );
+        }
+    }
+
+    public void close() {
+        if(verifiedRebuildJob != null)
+            verifiedRebuildJob.cancel();
+        verifiedRebuildJob = null;
+    }
+
+    private void startStartupRebuildIfNeeded() {
+        if(startupRebuildStarted || !(world instanceof ServerLevel))
+            return;
+        startupRebuildStarted = true;
+        var start = startVerifiedRebuild(new TransmissionNetworkRebuildJob.Listener() {
+            @Override
+            public void completed(TransmissionNetworkRebuildJob.Outcome outcome) {
+                if(outcome.complete()) {
+                    PowerGrid.LOGGER.info(
+                            "Startup transmission rebuild completed successfully in {}",
+                            world.dimension().location()
+                    );
+                } else {
+                    PowerGrid.LOGGER.warn(
+                            "Startup transmission rebuild completed partially in {}: {} unresolved parts, {} parts queued for retry",
+                            world.dimension().location(),
+                            outcome.unresolvedParts(),
+                            outcome.rebuild().retryingParts()
+                    );
+                }
+            }
+
+            @Override
+            public void failed(TransmissionNetworkRebuildJob.Failure failure) {
+                PowerGrid.LOGGER.error(
+                        "Startup transmission rebuild failed in {}: {}",
+                        world.dimension().location(),
+                        failure.reason()
+                );
+            }
+        });
+        if(start.status() == VerifiedRebuildStartStatus.TOO_MANY_CHUNKS) {
+            PowerGrid.LOGGER.error(
+                    "Startup transmission rebuild refused in {}: {} unique chunks exceeds the limit of {}",
+                    world.dimension().location(),
+                    start.requestedChunks(),
+                    TransmissionNetworkRebuildJob.MAX_UNIQUE_CHUNKS
+            );
+        } else if(start.status() == VerifiedRebuildStartStatus.STARTED) {
+            var info = Objects.requireNonNull(start.info());
+            PowerGrid.LOGGER.info(
+                    "Startup transmission rebuild scheduled in {}: {} physical parts, {} unique chunks, {} batches",
+                    world.dimension().location(),
+                    info.parts(),
+                    info.uniqueChunks(),
+                    info.batches()
+            );
+        }
+    }
+
+    private void tickVerifiedRebuild() {
+        if(verifiedRebuildJob == null)
+            return;
+        verifiedRebuildJob.tick();
+        if(verifiedRebuildJob.isFinished())
+            verifiedRebuildJob = null;
+    }
+
     public void postTick() {
+        if(verifiedRebuildIsolated)
+            return;
         if(world instanceof ServerLevel serverWorld) {
             // Check for line parts existence
             var checkIter = checkForExistence.entrySet().iterator();
@@ -297,12 +470,22 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
                     if(expectedInChunks.containsKey(chunk)) {
                         expectedInChunks.get(chunk).addAll(entry.getValue().entities);
                     } else {
-                        entry.getValue().ticks = 0;
+                        entry.getValue().resetTicks();
                         expectedInChunks.put(chunk, entry.getValue());
                     }
+                    checkIter.remove();
                     continue;
                 }
-                var remove = entry.getValue().ticks++ >= 10;
+                var chunkCheckPos = new BlockPos(
+                        chunk.getMinBlockX(),
+                        serverWorld.getMinBuildHeight(),
+                        chunk.getMinBlockZ()
+                );
+                if(!serverWorld.isPositionEntityTicking(chunkCheckPos)) {
+                    entry.getValue().resetTicks();
+                    continue;
+                }
+                var remove = entry.getValue().advanceEntityLoadCheck();
                 var entityIter = entry.getValue().entities.iterator();
                 while(entityIter.hasNext()) {
                     var id = entityIter.next();
@@ -310,15 +493,14 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
                         if(remove) {
                             // Doesn't exist even after chunk has been loaded.
                             var part = lineParts.get(id);
-                            if (part == null)
+                            if (part == null) {
+                                entityIter.remove();
                                 continue;
-                            // Destroy line
-                            var line = part.getLine();
-                            if(line != null) {
-                                line.remove();
-                            } else {
-                                part.remove();
                             }
+                            // Only the missing physical segment is invalid. Removing the
+                            // entire optimized line would orphan every surviving segment.
+                            part.remove();
+                            entityIter.remove();
                         }
                     } else {
                         entityIter.remove();
@@ -448,6 +630,16 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         addAndMigrateNode(endpoint);
     }
 
+    public void putInNetwork(@NotNull IWireEndpoint endpoint) {
+        var node = endpoint.getNode(world);
+        add(endpoint);
+        var line = findLineMiddle(node);
+        if(line != null)
+            return;
+        if(node.getNetwork() == null)
+            endpoint.joinNetwork(world, newNetwork());
+    }
+
     public int connectionCount(IWireEndpoint endpoint) {
         return globalGraph.connectionCount(endpoint.getNode(world));
     }
@@ -466,16 +658,6 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
             }
         }
         return null;
-    }
-
-    public void putInNetwork(@NotNull IWireEndpoint endpoint) {
-        var node = endpoint.getNode(world);
-        add(endpoint);
-        var line = findLineMiddle(node);
-        if(line != null)
-            return;
-        if(node.getNetwork() == null)
-            endpoint.joinNetwork(world, newNetwork());
     }
 
     @Nullable
@@ -588,6 +770,35 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         return network;
     }
 
+    /**
+     * Connect a newly assembled transmission line only after rebinding it to the
+     * endpoint nodes selected during connection preparation.
+     */
+    public void addPreparedTransmissionLine(
+            @NotNull ElectricalNetwork network,
+            @NotNull TransmissionLine line
+    ) {
+        if(line.getNetwork() != null)
+            throw new IllegalStateException("Transmission line is already connected");
+
+        line.refreshDetachedEndpointNodes();
+        inNetwork(network, line.getNode1(), line.getEndpoint1());
+        inNetwork(network, line.getNode2(), line.getEndpoint2());
+        if(!network.ownsNode(line.getNode1()) || !network.ownsNode(line.getNode2())) {
+            throw new IllegalStateException(
+                    "Prepared transmission line endpoints do not belong to the target network"
+                            + " (endpoint1=" + line.getEndpoint1()
+                            + ", node1=" + line.getNode1()
+                            + ", node1Network=" + line.getNode1().getNetwork()
+                            + ", endpoint2=" + line.getEndpoint2()
+                            + ", node2=" + line.getNode2()
+                            + ", node2Network=" + line.getNode2().getNetwork()
+                            + ", targetNetwork=" + network + ")"
+            );
+        }
+        network.addWire(line);
+    }
+
     @Nullable
     public ElectricalNetwork prepareForConnection(@NotNull OwnedFloatingNode node1, @NotNull OwnedFloatingNode node2) {
         var endpoint1 = node1.endpoint;
@@ -645,35 +856,47 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
         var existingPart = lineParts.get(id);
         if(existingPart != null) {
-            existingPart.grab(forEntity, id);
-            return existingPart;
+            if(!existingPart.endpointsMatch(endpoint1, endpoint2)) {
+                PowerGrid.LOGGER.warn(
+                        "Replacing stale transmission part {} from physical owner: stored=({}, {}), current=({}, {})",
+                        id,
+                        existingPart.getConnectionEndpoint1(),
+                        existingPart.getConnectionEndpoint2(),
+                        endpoint1,
+                        endpoint2
+                );
+                // Remove only the stale part. Removing its optimized
+                // TransmissionLine would unregister every healthy segment.
+                existingPart.remove();
+                return null;
+            }
+            if(existingPart.grab(forEntity, id))
+                return existingPart;
+            return null;
         }
 
         return null;
     }
 
     private boolean makeTransmissionLine(TransmissionLinePart linePart) {
+        if(!transmissionTopologyResolutionAllowed())
+            return false;
         if(linePart.getLine() != null)
             return true;
 
         var endpoint1 = linePart.getEndpoint1();
         var endpoint2 = linePart.getEndpoint2();
+        linePart.refreshEndpointNodes();
+        var node1 = linePart.getNode1();
+        var node2 = linePart.getNode2();
 
         // This method needs to ensure proper ordering of segments in the transmission line.
-        var network = prepareForConnection(endpoint1, endpoint2);
+        var network = prepareForConnection(node1, node2);
         if(network == null)
             return false;
 
         if(ModdedConfigs.logsEnabled())
             PowerGrid.LOGGER.debug("Creating a transmission line for {}", linePart);
-        var node1 = endpoint1.getNode(world);
-        var node2 = endpoint2.getNode(world);
-
-        // Make sure nodes are up-to-date
-        movePartMap(linePart.getNode1(), node1, linePart);
-        linePart.setNode1(node1);
-        movePartMap(linePart.getNode2(), node2, linePart);
-        linePart.setNode2(node2);
 
         int nConns1 = connectionCount(endpoint1);
         int nConns2 = connectionCount(endpoint2);
@@ -735,10 +958,17 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
             line1.addLastSegment(linePart);
         }
         if(line1 == null && line2 == null) {
-            var line = new TransmissionLine(linePart.getResistance(), endpoint1, endpoint2, this);
+            var line = new TransmissionLine(
+                    linePart.getResistance(),
+                    endpoint1,
+                    endpoint2,
+                    node1,
+                    node2,
+                    this
+            );
             linePart.setLine(line);
             line.segments.add(linePart);
-            network.addWire(line);
+            addPreparedTransmissionLine(network, line);
             if(ModdedConfigs.logsEnabled())
                 PowerGrid.LOGGER.debug("{}: New transmission line between {} and {}", line, node1, node2);
         }
@@ -765,6 +995,9 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
 
     @Nullable
     public ElectricWire makeTransmissionLine(IWireEndpoint endpoint1, IWireEndpoint endpoint2, BaseWireEntity forEntity, PartId id) {
+        if(verifiedRebuildIsolated && !assemblingTransmissionTopology)
+            return registerIsolatedTransmissionPart(endpoint1, endpoint2, forEntity, id);
+
         add(endpoint1);
         add(endpoint2);
 
@@ -778,6 +1011,38 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         if(makeTransmissionLine(linePart))
             return linePart;
         return null;
+    }
+
+    @Nullable
+    private TransmissionLinePart registerIsolatedTransmissionPart(
+            IWireEndpoint endpoint1,
+            IWireEndpoint endpoint2,
+            BaseWireEntity forEntity,
+            PartId id
+    ) {
+        var existingPart = lineParts.get(id);
+        if(existingPart != null && !existingPart.endpointsMatch(endpoint1, endpoint2)) {
+            PowerGrid.LOGGER.warn(
+                    "Replacing stale transmission part {} from physical owner while rebuild topology is isolated: stored=({}, {}), current=({}, {})",
+                    id,
+                    existingPart.getConnectionEndpoint1(),
+                    existingPart.getConnectionEndpoint2(),
+                    endpoint1,
+                    endpoint2
+            );
+            existingPart.remove();
+            existingPart = null;
+        }
+        if(existingPart != null)
+            return existingPart.grab(forEntity, id) ? existingPart : null;
+        return TransmissionLinePart.uniquePart(
+                forEntity.getResistance(),
+                endpoint1,
+                endpoint2,
+                forEntity,
+                this,
+                id
+        );
     }
 
     public List<TransmissionLinePart> findConnectedWires(ElectricBehaviour behaviour) {
@@ -806,6 +1071,289 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         deferredRewireEntities.add(part);
     }
 
+    /**
+     * Rebuild the derived transmission-line topology from the persisted physical
+     * line parts. Placed blocks, wire entities and saved line parts are preserved.
+     * This must run on the owning server thread.
+     */
+    public RebuildResult rebuildTransmissionNetwork() {
+        return rebuildTransmissionNetwork(-1);
+    }
+
+    private RebuildResult rebuildTransmissionNetwork(int linesBeforeOverride) {
+        if(world.isClientSide)
+            throw new IllegalStateException("Transmission networks can only be rebuilt on the server");
+
+        rebuildRetryQueue.clear();
+        var parts = new ArrayList<>(lineParts.values());
+        parts.sort(Comparator.comparing(part -> part.persistentOwnerId.toString()));
+
+        var detachedLines = detachDerivedTransmissionTopology();
+        var linesBefore = linesBeforeOverride >= 0 ? linesBeforeOverride : detachedLines;
+
+        for(var part : parts) {
+            part.setLine(null);
+            restorePartEndpointNodes(part);
+        }
+
+        // Recreate the node index from the persisted source of truth as well. The
+        // regular entity reload path will continue to migrate entries afterwards.
+        partNodeMap.clear();
+        for(var part : parts) {
+            partNodeMap.computeIfAbsent(part.getNode1(), $ -> new HashSet<>()).add(part);
+            partNodeMap.computeIfAbsent(part.getNode2(), $ -> new HashSet<>()).add(part);
+        }
+        deferredRewireEntities.clear();
+
+        int retryingParts = 0;
+        assemblingTransmissionTopology = true;
+        try {
+            for(var part : parts) {
+                if(!makeTransmissionLine(part)) {
+                    scheduleRebuildRetry(part);
+                    logRebuildFailure(part, 0, false, null);
+                    ++retryingParts;
+                }
+            }
+        } finally {
+            assemblingTransmissionTopology = false;
+        }
+
+        for(var network : subnetworks)
+            network.setDirty();
+        setDirty();
+
+        var result = new RebuildResult(
+                parts.size(),
+                linesBefore,
+                transmissionLines.size(),
+                retryingParts,
+                MAX_AUTOMATIC_REBUILD_RETRIES
+        );
+        PowerGrid.LOGGER.info(
+                "Rebuilt transmission network in {}: {} physical parts, {} lines before, {} lines after, {} parts queued for at most {} automatic retries",
+                world.dimension().location(),
+                result.parts(),
+                result.linesBefore(),
+                result.linesAfter(),
+                result.retryingParts(),
+                result.retryLimit()
+        );
+        return result;
+    }
+
+    private int detachDerivedTransmissionTopology() {
+        var oldLines = Collections.newSetFromMap(new IdentityHashMap<TransmissionLine, Boolean>());
+        oldLines.addAll(transmissionLines.values());
+        for(var part : lineParts.values()) {
+            if(part.getLine() != null)
+                oldLines.add(part.getLine());
+        }
+
+        for(var line : oldLines)
+            line.detachForRebuild();
+        transmissionLines.clear();
+        for(var part : lineParts.values())
+            part.setLine(null);
+        return oldLines.size();
+    }
+
+    private void beginVerifiedRebuildIsolation() {
+        if(verifiedRebuildIsolated)
+            throw new IllegalStateException("Verified rebuild topology is already isolated");
+
+        verifiedRebuildIsolated = true;
+        islandDiscoveryQueue.clear();
+        rebuildRetryQueue.clear();
+        try {
+            verifiedRebuildLinesBefore = detachDerivedTransmissionTopology();
+        } catch(RuntimeException exception) {
+            verifiedRebuildIsolated = false;
+            throw exception;
+        }
+    }
+
+    RebuildResult completeVerifiedRebuildIsolation() {
+        if(!verifiedRebuildIsolated)
+            throw new IllegalStateException("Verified rebuild topology is not isolated");
+
+        var result = rebuildTransmissionNetwork(verifiedRebuildLinesBefore);
+        verifiedRebuildIsolated = false;
+        verifiedRebuildLinesBefore = 0;
+        scheduleDiscoveryForAllNetworks();
+        return result;
+    }
+
+    RebuildResult refreshVerifiedRebuildResult(RebuildResult initialResult) {
+        return new RebuildResult(
+                lineParts.size(),
+                initialResult.linesBefore(),
+                transmissionLines.size(),
+                rebuildRetryQueue.size(),
+                MAX_AUTOMATIC_REBUILD_RETRIES
+        );
+    }
+
+    void abortVerifiedRebuildIsolation() {
+        if(!verifiedRebuildIsolated)
+            return;
+
+        try {
+            rebuildTransmissionNetwork(verifiedRebuildLinesBefore);
+        } catch(RuntimeException exception) {
+            PowerGrid.LOGGER.error(
+                    "Failed to restore transmission topology after an aborted verified rebuild in {}; leaving transmission lines disconnected",
+                    world.dimension().location(),
+                    exception
+            );
+            try {
+                detachDerivedTransmissionTopology();
+            } catch(RuntimeException detachException) {
+                exception.addSuppressed(detachException);
+            }
+        } finally {
+            verifiedRebuildIsolated = false;
+            verifiedRebuildLinesBefore = 0;
+            scheduleDiscoveryForAllNetworks();
+        }
+    }
+
+    private void scheduleDiscoveryForAllNetworks() {
+        islandDiscoveryQueue.clear();
+        islandDiscoveryQueue.addAll(subnetworks);
+    }
+
+    private void scheduleRebuildRetry(TransmissionLinePart part) {
+        rebuildRetryQueue.put(
+                part.persistentOwnerId,
+                new RebuildRetry(part, world.getGameTime() + REBUILD_RETRY_INTERVAL_TICKS)
+        );
+    }
+
+    private void processRebuildRetries() {
+        if(rebuildRetryQueue.isEmpty())
+            return;
+
+        var currentTick = world.getGameTime();
+        int attemptsThisTick = 0;
+        var iterator = rebuildRetryQueue.entrySet().iterator();
+        while(iterator.hasNext() && attemptsThisTick < MAX_REBUILD_RETRIES_PER_TICK) {
+            var entry = iterator.next();
+            var retry = entry.getValue();
+            var part = retry.part;
+
+            if(lineParts.get(entry.getKey()) != part) {
+                iterator.remove();
+                continue;
+            }
+            if(part.getLine() != null) {
+                PowerGrid.LOGGER.info(
+                        "Transmission part {} resolved before its queued retry in {}",
+                        part.persistentOwnerId,
+                        world.dimension().location()
+                );
+                iterator.remove();
+                continue;
+            }
+            if(currentTick < retry.nextAttemptTick)
+                continue;
+            if(!retry.budget.tryAcquire()) {
+                iterator.remove();
+                continue;
+            }
+
+            ++attemptsThisTick;
+            restorePartEndpointNodes(part);
+            try {
+                if(makeTransmissionLine(part)) {
+                    PowerGrid.LOGGER.info(
+                            "Transmission part {} rebuilt automatically on retry {}/{} in {}",
+                            part.persistentOwnerId,
+                            retry.budget.attempts(),
+                            MAX_AUTOMATIC_REBUILD_RETRIES,
+                            world.dimension().location()
+                    );
+                    iterator.remove();
+                    continue;
+                }
+                logRebuildFailure(part, retry.budget.attempts(), retry.budget.exhausted(), null);
+            } catch(RuntimeException exception) {
+                logRebuildFailure(part, retry.budget.attempts(), retry.budget.exhausted(), exception);
+            }
+
+            if(retry.budget.exhausted()) {
+                iterator.remove();
+            } else {
+                retry.nextAttemptTick = currentTick + REBUILD_RETRY_INTERVAL_TICKS;
+            }
+        }
+    }
+
+    private void restorePartEndpointNodes(TransmissionLinePart part) {
+        var endpoint1 = part.getConnectionEndpoint1();
+        var endpoint2 = part.getConnectionEndpoint2();
+        var node1 = holderOrPlaceholderNode(endpoint1);
+        var node2 = holderOrPlaceholderNode(endpoint2);
+
+        movePartMap(part.getNode1(), node1, part);
+        part.setNode1(node1);
+        movePartMap(part.getNode2(), node2, part);
+        part.setNode2(node2);
+        part.refreshEndpointNodes();
+    }
+
+    private void logRebuildFailure(TransmissionLinePart part, int retryAttempt, boolean exhausted, @Nullable RuntimeException exception) {
+        var endpoint1 = part.getConnectionEndpoint1();
+        var endpoint2 = part.getConnectionEndpoint2();
+        var node1 = part.getNode1();
+        var node2 = part.getNode2();
+        String reason;
+        if(endpoint1.equals(endpoint2)) {
+            reason = "identical endpoints";
+        } else if(node1 == node2) {
+            reason = "both endpoints resolve to the same node";
+        } else {
+            reason = "connection preparation returned no network";
+        }
+
+        var attempt = retryAttempt == 0
+                ? "initial rebuild"
+                : "automatic retry " + retryAttempt + "/" + MAX_AUTOMATIC_REBUILD_RETRIES;
+        var state = exhausted ? "retry limit exhausted" : "retry pending";
+        if(exception == null) {
+            PowerGrid.LOGGER.warn(
+                    "Failed to rebuild transmission part {} during {} in {} ({}; {}; endpoint1={}, endpoint2={}, node1={}, node2={}, lastKnownChunk={}, ownerLoaded={})",
+                    part.persistentOwnerId,
+                    attempt,
+                    world.dimension().location(),
+                    reason,
+                    state,
+                    endpoint1,
+                    endpoint2,
+                    node1,
+                    node2,
+                    part.lastKnownChunk,
+                    part.owner != null && !part.owner.isRemoved()
+            );
+        } else {
+            PowerGrid.LOGGER.error(
+                    "Exception while rebuilding transmission part {} during {} in {} ({}; {}; endpoint1={}, endpoint2={}, node1={}, node2={}, lastKnownChunk={}, ownerLoaded={})",
+                    part.persistentOwnerId,
+                    attempt,
+                    world.dimension().location(),
+                    reason,
+                    state,
+                    endpoint1,
+                    endpoint2,
+                    node1,
+                    node2,
+                    part.lastKnownChunk,
+                    part.owner != null && !part.owner.isRemoved(),
+                    exception
+            );
+        }
+    }
+
     @Override
     public CompoundTag save(CompoundTag tag, HolderLookup.Provider registries) {
         var partList = new ListTag();
@@ -825,32 +1373,18 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
     }
 
     public void nodeHolderUnloaded(@NotNull OwnedFloatingNode ownedNode) {
-        // Here, we need to choose between preserving transmission line junction nodes or removing them.
-        // A transmission line should be preserved if terminates on a junction which connects to more
-        // transmission lines.
-        Collection<TransmissionLine> lines;
-        while(true) {
-            lines = globalGraph.getConnectedLines(ownedNode);
-            if(lines.size() != 1 || globalGraph.connectionCount(ownedNode) != 1) {
-                // We CANNOT delete the node, as it still is part of a bigger circuit.
-                break;
-            }
-            // No need to keep this line (or the node).
-            var line = lines.iterator().next();
-            var removeNode = ownedNode;
-            if(line.getNode1() == ownedNode) {
-                ownedNode = line.getNode2();
-            } else {
-                assert line.getNode2() == ownedNode;
-                ownedNode = line.getNode1();
-            }
-            // Also, we need to inform the wire entities about this.
-            line.unresolve();
-            setDirty();
-            scheduleIslandDiscovery(removeNode.getNetwork());
-            removeNode.remove();
-            globalExternalNodes.remove(removeNode.endpoint);
-        }
+        var affectedNetwork = ownedNode.getNetwork();
+        // An ordinary chunk unload must not tear down a healthy derived line.
+        // The verified rebuild deliberately assembles the complete passive
+        // topology from persisted parts, including unloaded chunks. Preserve
+        // that topology and replace only the departing block-owned node.
+        //
+        // TransmissionLine#setNodeN rewires the existing line in both the
+        // solver network and the global graph, while addAndMigrateNode also
+        // moves every physical-part index entry and endpoint alias.
+        addAndMigrateNode(ownedNode, new OwnedFloatingNode(ownedNode.endpoint));
+        scheduleIslandDiscovery(affectedNetwork);
+        setDirty();
     }
 
     public void nodeHolderRemoved(@NotNull OwnedFloatingNode ownedNode) {
@@ -868,104 +1402,174 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         }
         scheduleIslandDiscovery(ownedNode.getNetwork());
         ownedNode.remove();
-        globalExternalNodes.remove(ownedNode.endpoint);
+        globalExternalNodes.entrySet().removeIf(entry -> entry.getValue() == ownedNode);
     }
 
-    private boolean traceTree(IWireEndpoint endpoint, Set<IWireEndpoint> visited) {
-        if(!visited.add(endpoint))
+    private boolean traceTree(OwnedFloatingNode endpointNode, Set<OwnedFloatingNode> visited) {
+        if(!visited.add(endpointNode))
             return false;
-        Collection<TransmissionLinePart> parts = partNodeMap.get(globalExternalNodes.get(endpoint));
+        Collection<TransmissionLinePart> parts = partNodeMap.get(endpointNode);
         if(parts == null)
             return false;
-        // Make sure endpoints are always up to date in line parts.
-        // TODO: Verify that this doesn't brake a bunch of things
-        addAndMigrateNode(endpoint);
         parts = List.copyOf(parts);
         boolean continueResolving = false;
         for(var part : parts) {
+            var side = transmissionPartSide(
+                    part.getNode1(),
+                    part.getNode2(),
+                    endpointNode
+            );
             if(part.getLine() != null) {
                 // This branch connects to a valid line, back-trace and resolve all line parts.
                 continueResolving = true;
             }
             if(parts.size() == 1) {
                 if(ModdedConfigs.logsEnabled())
-                    PowerGrid.LOGGER.debug("Found edge line at {}", endpoint);
-                if(part.getEndpoint1().equals(endpoint)) {
+                    PowerGrid.LOGGER.debug("Found edge line at {}", endpointNode);
+                if(side == TransmissionPartSide.FIRST) {
                     // Check endpoint2
-                    if(part.getEndpoint2().isValid(world)) {
+                    if(part.getConnectionEndpoint2().isValid(world)) {
                         // Resolve segment
                         makeTransmissionLine(part);
                         return true;
                     }
-                } else if(part.getEndpoint2().equals(endpoint)) {
+                } else if(side == TransmissionPartSide.SECOND) {
                     // Check endpoint1
-                    if(part.getEndpoint1().isValid(world)) {
+                    if(part.getConnectionEndpoint1().isValid(world)) {
                         // Resolve segment
                         makeTransmissionLine(part);
                         return true;
                     }
                 } else {
-                    PowerGrid.LOGGER.warn("[1] Part was expected to have this endpoint");
+                    PowerGrid.LOGGER.warn(
+                            "Transmission part {} was indexed under a node it does not contain: indexedNode={}, node1={}, node2={}",
+                            part.persistentOwnerId,
+                            endpointNode,
+                            part.getNode1(),
+                            part.getNode2()
+                    );
                 }
                 break;
             }
             if(ModdedConfigs.logsEnabled())
-                PowerGrid.LOGGER.debug("Continuing line trace through {}", endpoint);
-            if(part.getEndpoint1().equals(endpoint)) {
-                if(traceTree(part.getEndpoint2(), visited)) {
+                PowerGrid.LOGGER.debug("Continuing line trace through {}", endpointNode);
+            if(side == TransmissionPartSide.FIRST) {
+                if(traceTree(part.getNode2(), visited)) {
                     makeTransmissionLine(part);
                     continueResolving = true;
                 }
-            } else if(part.getEndpoint2().equals(endpoint)) {
-                if(traceTree(part.getEndpoint1(), visited)) {
+            } else if(side == TransmissionPartSide.SECOND) {
+                if(traceTree(part.getNode1(), visited)) {
                     makeTransmissionLine(part);
                     continueResolving = true;
                 }
             } else {
-                PowerGrid.LOGGER.warn("[2] Part was expected to have this endpoint");
+                PowerGrid.LOGGER.warn(
+                        "Transmission part {} was indexed under a node it does not contain while tracing: indexedNode={}, node1={}, node2={}",
+                        part.persistentOwnerId,
+                        endpointNode,
+                        part.getNode1(),
+                        part.getNode2()
+                );
             }
         }
         return continueResolving;
     }
 
+    static TransmissionPartSide transmissionPartSide(
+            @NotNull OwnedFloatingNode node1,
+            @NotNull OwnedFloatingNode node2,
+            @NotNull OwnedFloatingNode indexedNode
+    ) {
+        if(node1 == indexedNode)
+            return TransmissionPartSide.FIRST;
+        if(node2 == indexedNode)
+            return TransmissionPartSide.SECOND;
+        return TransmissionPartSide.NONE;
+    }
+
     private void resolveTree(@NotNull IWireEndpoint endpoint) {
-        var unresolvedLines = partNodeMap.get(globalExternalNodes.get(endpoint));
+        if(!transmissionTopologyResolutionAllowed())
+            return;
+        var endpointNode = holderOrPlaceholderNode(endpoint);
+        var unresolvedLines = partNodeMap.get(endpointNode);
         if(unresolvedLines == null)
             return;
         // We need to trace the graph to all terminating nodes and see if any are loaded,
         // if so, we need to resolve all lines between them to ensure correct unloaded chunk behaviour.
-        var visited = new HashSet<IWireEndpoint>();
+        var visited = Collections.newSetFromMap(
+                new IdentityHashMap<OwnedFloatingNode, Boolean>()
+        );
         if(ModdedConfigs.logsEnabled())
-            PowerGrid.LOGGER.debug("Starting line trace at {}", endpoint);
-        traceTree(endpoint, visited);
+            PowerGrid.LOGGER.debug(
+                    "Starting line trace at connection endpoint {} resolved as {}",
+                    endpoint,
+                    endpointNode
+            );
+        traceTree(endpointNode, visited);
     }
 
     public void addAndMigrateNode(IWireEndpoint endpoint) {
         var newNode = endpoint.getNode(world);
         if(newNode == null)
             return;
-        addAndMigrateNode(newNode);
+        addAndMigrateNode(endpoint, newNode, NodeBindingMode.BIND_ONLY);
     }
 
     public void addAndMigrateNode(OwnedFloatingNode newNode) {
-        var endpoint = newNode.endpoint;
-        var oldNode = globalExternalNodes.put(endpoint, newNode);
-        addAndMigrateNode(oldNode, newNode);
+        bindEndpointNode(newNode.endpoint, newNode);
     }
 
-    public void addAndMigrateNode(IWireEndpoint oldEndpoint, OwnedFloatingNode newNode) {
+    public void addAndMigrateNode(IWireEndpoint endpointAlias, OwnedFloatingNode newNode) {
+        addAndMigrateNode(endpointAlias, newNode, NodeBindingMode.BIND_AND_SPLIT);
+    }
+
+    private void addAndMigrateNode(
+            IWireEndpoint endpointAlias,
+            OwnedFloatingNode newNode,
+            NodeBindingMode mode
+    ) {
         if(newNode == null)
             return;
-        var endpoint = newNode.endpoint;
-        var oldNode = globalExternalNodes.put(endpoint, newNode);
-        addAndMigrateNode(oldNode, newNode);
-        var oldNode2 = globalExternalNodes.remove(oldEndpoint);
-        addAndMigrateNode(oldNode2, newNode);
+        bindCanonicalAndAlias(endpointAlias, newNode);
 
-        var line = findLineMiddle(newNode);
-        if(line != null) {
-            line.splitAt(newNode);
+        if(shouldSplitAfterNodeBinding(mode, transmissionTopologyResolutionAllowed())) {
+            var line = findLineMiddle(newNode);
+            if(line != null)
+                line.splitAt(newNode);
         }
+    }
+
+    static boolean shouldSplitAfterNodeBinding(
+            NodeBindingMode mode,
+            boolean topologyResolutionAllowed
+    ) {
+        return mode == NodeBindingMode.BIND_AND_SPLIT
+                && topologyResolutionAllowed;
+    }
+
+    private void bindCanonicalAndAlias(
+            @NotNull IWireEndpoint endpointAlias,
+            @NotNull OwnedFloatingNode node
+    ) {
+        bindEndpointNode(node.endpoint, node);
+        if(!node.endpoint.equals(endpointAlias))
+            bindEndpointNode(endpointAlias, node);
+    }
+
+    private void bindEndpointNode(
+            @NotNull IWireEndpoint endpoint,
+            @NotNull OwnedFloatingNode node
+    ) {
+        var previousNode = globalExternalNodes.put(endpoint, node);
+        addAndMigrateNode(previousNode, node);
+    }
+
+    public void removeEndpointAlias(
+            @NotNull IWireEndpoint endpointAlias,
+            @NotNull OwnedFloatingNode expectedNode
+    ) {
+        globalExternalNodes.remove(endpointAlias, expectedNode);
     }
 
     public void addAndMigrateNode(OwnedFloatingNode oldNode, OwnedFloatingNode newNode) {
@@ -977,8 +1581,9 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
             // This happens when a block entity is loaded but its terminal was acting as a transmission line junction.
             if(ModdedConfigs.logsEnabled())
                 PowerGrid.LOGGER.debug("Migrating external node from {} to {}", oldNode, newNode);
-            var parts = partNodeMap.remove(oldNode);
-            if(parts != null) {
+            rebindNodeAliasesByIdentity(globalExternalNodes, oldNode, newNode);
+            var parts = moveNodeIndex(partNodeMap, oldNode, newNode);
+            if(!parts.isEmpty()) {
                 for(TransmissionLinePart part : parts) {
                     if(ModdedConfigs.logsEnabled())
                         PowerGrid.LOGGER.debug("Migrating node for part {}", part);
@@ -1010,7 +1615,6 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
                             }
                         }
                     }
-                    partNodeMap.computeIfAbsent(newNode, $ -> new HashSet<>()).add(part);
                 }
             }
             if(oldNode.getNetwork() != null) {
@@ -1053,10 +1657,33 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         }
     }
 
+    static void rebindNodeAliasesByIdentity(
+            Map<IWireEndpoint, OwnedFloatingNode> endpointBindings,
+            OwnedFloatingNode oldNode,
+            OwnedFloatingNode newNode
+    ) {
+        endpointBindings.replaceAll((endpoint, node) -> node == oldNode ? newNode : node);
+        endpointBindings.put(oldNode.endpoint, newNode);
+    }
+
+    static <T> List<T> moveNodeIndex(
+            Map<OwnedFloatingNode, Set<T>> nodeIndex,
+            OwnedFloatingNode oldNode,
+            OwnedFloatingNode newNode
+    ) {
+        var moved = nodeIndex.remove(oldNode);
+        if(moved == null || moved.isEmpty())
+            return List.of();
+        nodeIndex.computeIfAbsent(newNode, $ -> new HashSet<>()).addAll(moved);
+        return List.copyOf(moved);
+    }
+
     public void nodeHolderAdded(@NotNull OwnedFloatingNode ownedNode, boolean hasInternals) {
         if(ModdedConfigs.logsEnabled())
             PowerGrid.LOGGER.debug("Node holder added, {}", ownedNode);
         addAndMigrateNode(ownedNode.endpoint);
+        if(!transmissionTopologyResolutionAllowed())
+            return;
         // Try to resolve an end of a transmission line
         resolveTree(ownedNode.endpoint);
         if(hasInternals) {
@@ -1071,9 +1698,25 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
     public void prepareUnpaused(OwnedFloatingNode node) {
         if(ModdedConfigs.logsEnabled())
             PowerGrid.LOGGER.debug("Preparing node for unpaused internal connections");
+        if(!transmissionTopologyResolutionAllowed())
+            return;
         var line = findLineMiddle(node);
         if(line != null)
             line.splitAt(node);
+    }
+
+    private boolean transmissionTopologyResolutionAllowed() {
+        return transmissionTopologyResolutionAllowed(
+                verifiedRebuildIsolated,
+                assemblingTransmissionTopology
+        );
+    }
+
+    static boolean transmissionTopologyResolutionAllowed(
+            boolean verifiedRebuildIsolated,
+            boolean assemblingTransmissionTopology
+    ) {
+        return !verifiedRebuildIsolated || assemblingTransmissionTopology;
     }
 
     /**
@@ -1088,6 +1731,13 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
             return;
         }
         expectedInChunks.computeIfAbsent(lastKnownChunk, $ -> new CheckChunk()).add(entityId);
+    }
+
+    public void unloadPartsOwnedBy(BaseWireEntity owner) {
+        for(var part : lineParts.values()) {
+            if(part.owner == owner)
+                part.unload();
+        }
     }
 
     public void tracking(ServerPlayer tracker, IWireEndpoint endpoint, boolean end) {
@@ -1125,16 +1775,31 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
     }
 
     public OwnedFloatingNode holderOrPlaceholderNode(@NotNull IWireEndpoint endpoint) {
-        var node = globalExternalNodes.get(endpoint);
-        if (node != null)
-            return node;
+        var indexedNode = globalExternalNodes.get(endpoint);
+
+        OwnedFloatingNode loadedNode = null;
         if(endpoint.isValid(world)) {
-            node = endpoint.getNode(world);
-        } else {
-            node = new OwnedFloatingNode(endpoint);
+            loadedNode = endpoint.getNode(world);
         }
-        globalExternalNodes.put(endpoint, node);
-        return node;
+
+        var selectedNode = selectLoadedOrIndexedNode(endpoint, indexedNode, loadedNode);
+        bindCanonicalAndAlias(endpoint, selectedNode);
+        return selectedNode;
+    }
+
+    static OwnedFloatingNode selectLoadedOrIndexedNode(
+            @NotNull IWireEndpoint endpoint,
+            @Nullable OwnedFloatingNode indexedNode,
+            @Nullable OwnedFloatingNode loadedNode
+    ) {
+        // A proxy endpoint may legitimately resolve to a node owned by the main
+        // block of a multiblock, so the node's canonical endpoint can differ
+        // from the endpoint used as the index key.
+        if(loadedNode != null)
+            return loadedNode;
+        if(indexedNode != null)
+            return indexedNode;
+        return new OwnedFloatingNode(endpoint);
     }
 
     public void registerPart(PartId persistentOwnerId, TransmissionLinePart part) {
@@ -1166,29 +1831,79 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         return lineParts.get(persistentOwnerId);
     }
 
+    Map<PartId, TransmissionLinePart> linePartsSnapshot() {
+        return Map.copyOf(lineParts);
+    }
+
+    boolean removeStalePartAfterVerifiedScan(PartId id) {
+        var part = lineParts.get(id);
+        if(part == null || part.owner != null)
+            return false;
+        PowerGrid.LOGGER.warn(
+                "Removing stale transmission registration {} after its owner and endpoint chunks were entity-ticking and no physical owner was found",
+                id
+        );
+        part.remove();
+        return true;
+    }
+
+    void removePartForVerifiedRefresh(PartId id, BaseWireEntity physicalOwner) {
+        if(id.getEntity((ServerLevel) world) != physicalOwner)
+            throw new IllegalArgumentException("Physical owner does not match the transmission part id");
+        var part = lineParts.get(id);
+        if(part != null)
+            part.remove();
+    }
+
     public void inNetwork(@Nullable ElectricalNetwork network, @NotNull OwnedFloatingNode node) {
+        inNetwork(network, node, node.endpoint);
+    }
+
+    public void inNetwork(
+            @Nullable ElectricalNetwork network,
+            @NotNull OwnedFloatingNode node,
+            @NotNull IWireEndpoint connectionEndpoint
+    ) {
         if(network == null)
             return;
-        if(node.getNetwork() != null) {
-            if(node.getNetwork() != network) {
-                network.merge(node.getNetwork());
-            }
-        } else {
-            node.endpoint.joinNetwork(world, network);
+        var currentNetwork = node.getNetwork();
+        if(currentNetwork != null && !currentNetwork.ownsNode(node))
+            node.setNetwork(null);
+        if(node.getNetwork() == null)
+            connectionEndpoint.joinNetwork(world, network);
+        addOrMergeExactNode(network, node);
+    }
+
+    static void addOrMergeExactNode(
+            @NotNull ElectricalNetwork network,
+            @NotNull OwnedFloatingNode node
+    ) {
+        var currentNetwork = node.getNetwork();
+        if(currentNetwork == network && network.ownsNode(node))
+            return;
+        if(currentNetwork != null && currentNetwork.ownsNode(node)) {
+            network.merge(currentNetwork);
+            return;
         }
+        if(currentNetwork != null)
+            node.setNetwork(null);
+        network.addNode(node);
     }
 
     public void movePartMap(OwnedFloatingNode oldNode, OwnedFloatingNode newNode, TransmissionLinePart part) {
-        if(oldNode == newNode || oldNode == null || newNode == null)
+        if(newNode == null)
             return;
-        var parts = partNodeMap.get(oldNode);
-        if(parts == null)
-            return;
-        if(parts.remove(part)) {
-            if (parts.isEmpty())
-                partNodeMap.remove(oldNode);
-            partNodeMap.computeIfAbsent(newNode, $ -> new HashSet<>()).add(part);
+        if(oldNode != null && oldNode != newNode) {
+            var parts = partNodeMap.get(oldNode);
+            if(parts != null) {
+                parts.remove(part);
+                if(parts.isEmpty())
+                    partNodeMap.remove(oldNode);
+            }
         }
+        // Re-add even if the old index entry was already missing. This keeps the
+        // node-to-part index self-healing during entity reloads.
+        partNodeMap.computeIfAbsent(newNode, $ -> new HashSet<>()).add(part);
     }
 
     public void removeFromNetwork(OwnedFloatingNode node) {
@@ -1212,18 +1927,26 @@ public class WorldNetworks extends SavedData implements NetworkGraph.IGraphModif
         }
     }
 
-    private static class CheckChunk {
+    static class CheckChunk {
         public final Set<PartId> entities = Sets.newConcurrentHashSet();
-        public int ticks = 0;
+        private int ticks = 0;
 
         public void add(PartId id) {
             entities.add(id);
-            ticks = 0;
+            resetTicks();
         }
 
         public void addAll(Set<PartId> ids) {
             entities.addAll(ids);
+            resetTicks();
+        }
+
+        public void resetTicks() {
             ticks = 0;
+        }
+
+        public boolean advanceEntityLoadCheck() {
+            return ticks++ >= ENTITY_LOAD_GRACE_TICKS;
         }
     }
 

--- a/src/main/java/org/patryk3211/powergrid/electricity/base/ElectricBehaviour.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/base/ElectricBehaviour.java
@@ -222,6 +222,9 @@ public class ElectricBehaviour extends BlockEntityBehaviour implements ISynchron
                 GlobalElectricNetworks.prepareUnpaused(this);
                 tracedAdd(new LinkedList<>(externalNodes));
                 element.unpaused();
+                // Internal circuit insertion can merge or reshape electrical
+                // islands after the transmission-line hooks have already run.
+                GlobalElectricNetworks.nodeHolderInternalsConnected(this);
             }
         }
     }

--- a/src/main/java/org/patryk3211/powergrid/electricity/base/ProxyElectricBehaviour.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/base/ProxyElectricBehaviour.java
@@ -106,6 +106,16 @@ public class ProxyElectricBehaviour extends ElectricBehaviour {
 
     @Override
     public void remove() {
+        var global = GlobalElectricNetworks.getWorldNetworks(getWorld());
+        for(var node : getExternalNodes()) {
+            if(node.endpoint instanceof BlockWireEndpoint endpoint) {
+                var thisEndpoint = new BlockWireEndpoint(
+                        getPos(),
+                        endpoint.getTerminal()
+                );
+                global.removeEndpointAlias(thisEndpoint, node);
+            }
+        }
         // Node holder might not be removed.
         breakConnections();
     }

--- a/src/main/java/org/patryk3211/powergrid/electricity/sim/ElectricalNetwork.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/sim/ElectricalNetwork.java
@@ -175,6 +175,10 @@ public class ElectricalNetwork implements IStamped {
         return nodes.get(index) == node;
     }
 
+    public boolean ownsNode(INode node) {
+        return hasNode(node) || leafNodes.containsKey(node);
+    }
+
     public void addNode(INode node) {
         if(hasNode(node) || leafNodes.containsKey(node))
             return;

--- a/src/main/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionConnectionEndpoints.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionConnectionEndpoints.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity.sim.special;
+
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.NotNull;
+import org.patryk3211.powergrid.electricity.wire.IWireEndpoint;
+import org.patryk3211.powergrid.electricity.wire.WireEndpointType;
+
+import java.util.Objects;
+
+/**
+ * The physical attachment points owned by a persisted transmission segment.
+ *
+ * <p>A multiblock proxy endpoint can resolve to a node whose canonical endpoint
+ * belongs to the main block. These connection endpoints must therefore remain
+ * independent from the nodes used by the electrical topology.</p>
+ */
+final class TransmissionConnectionEndpoints {
+    private static final String ENDPOINT_1_TAG = "Node1";
+    private static final String ENDPOINT_2_TAG = "Node2";
+
+    @NotNull
+    private final IWireEndpoint endpoint1;
+    @NotNull
+    private final IWireEndpoint endpoint2;
+
+    TransmissionConnectionEndpoints(
+            @NotNull IWireEndpoint endpoint1,
+            @NotNull IWireEndpoint endpoint2
+    ) {
+        this.endpoint1 = Objects.requireNonNull(endpoint1);
+        this.endpoint2 = Objects.requireNonNull(endpoint2);
+    }
+
+    static TransmissionConnectionEndpoints fromNbt(CompoundTag tag) {
+        return new TransmissionConnectionEndpoints(
+                WireEndpointType.deserialize(tag.getCompound(ENDPOINT_1_TAG)),
+                WireEndpointType.deserialize(tag.getCompound(ENDPOINT_2_TAG))
+        );
+    }
+
+    @NotNull
+    IWireEndpoint endpoint1() {
+        return endpoint1;
+    }
+
+    @NotNull
+    IWireEndpoint endpoint2() {
+        return endpoint2;
+    }
+
+    boolean matches(IWireEndpoint other1, IWireEndpoint other2) {
+        return sameEndpoints(endpoint1, endpoint2, other1, other2);
+    }
+
+    void writeToNbt(CompoundTag tag) {
+        tag.put(ENDPOINT_1_TAG, endpoint1.serialize());
+        tag.put(ENDPOINT_2_TAG, endpoint2.serialize());
+    }
+
+    static boolean sameEndpoints(
+            IWireEndpoint stored1,
+            IWireEndpoint stored2,
+            IWireEndpoint current1,
+            IWireEndpoint current2
+    ) {
+        return stored1.equals(current1) && stored2.equals(current2)
+                || stored1.equals(current2) && stored2.equals(current1);
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionLine.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionLine.java
@@ -52,7 +52,25 @@ public class TransmissionLine extends ElectricWire {
     private boolean splitting = false;
 
     public TransmissionLine(double resistance, IWireEndpoint endpoint1, IWireEndpoint endpoint2, WorldNetworks global) {
-        super(resistance, endpoint1.getNode(global.world), endpoint2.getNode(global.world));
+        this(
+                resistance,
+                endpoint1,
+                endpoint2,
+                global.holderOrPlaceholderNode(endpoint1),
+                global.holderOrPlaceholderNode(endpoint2),
+                global
+        );
+    }
+
+    public TransmissionLine(
+            double resistance,
+            IWireEndpoint endpoint1,
+            IWireEndpoint endpoint2,
+            OwnedFloatingNode node1,
+            OwnedFloatingNode node2,
+            WorldNetworks global
+    ) {
+        super(resistance, Objects.requireNonNull(node1), Objects.requireNonNull(node2));
         if(global.world.isClientSide && !(global.world instanceof PonderLevel))
             PowerGrid.LOGGER.warn("This method probably shouldn't be used on client-side");
         this.global = global;
@@ -63,25 +81,11 @@ public class TransmissionLine extends ElectricWire {
 
     // This should only be utilized by the client
     public TransmissionLine(int id, double resistance, OwnedFloatingNode node1, OwnedFloatingNode node2, WorldNetworks global) {
-        super(resistance, node1, node2);
+        super(resistance, Objects.requireNonNull(node1), Objects.requireNonNull(node2));
         if(!global.world.isClientSide)
             PowerGrid.LOGGER.warn("This method probably shouldn't be used on server-side");
         this.global = global;
         this.id = id;
-    }
-
-    private int validateEndpoints(TransmissionLinePart part, BaseWireEntity owner) {
-        if(part.getEndpoint1().equals(owner.getEndpoint1())) {
-            if(part.getEndpoint2().equals(owner.getEndpoint2())) {
-                return 1;
-            }
-        } else if(part.getEndpoint2().equals(owner.getEndpoint1())) {
-            // Endpoints are flipped
-            if(part.getEndpoint1().equals(owner.getEndpoint2())) {
-                return 2;
-            }
-        }
-        return 0;
     }
 
     public void validateLine() {
@@ -167,25 +171,26 @@ public class TransmissionLine extends ElectricWire {
         return endpoint2;
     }
 
-    public void grabPart(@NotNull BaseWireEntity owner, TransmissionLinePart part) {
-        if(part.persistentOwnerId.equals(owner.getUUID())) {
-            // If the owner id matches then the endpoints should match too
-            var endpointArrangement = validateEndpoints(part, owner);
-            if(endpointArrangement == 1 || endpointArrangement == 2) {
-                var node1 = part.getEndpoint1().getNode(owner.level());
-                var node2 = part.getEndpoint2().getNode(owner.level());
-                global.movePartMap(part.getNode1(), node1, part);
-                global.movePartMap(part.getNode2(), node2, part);
-                part.setNode1(node1);
-                part.setNode2(node2);
-                if(endpointArrangement == 2)
-                    owner.flipEndpoints();
-            } else {
-                PowerGrid.LOGGER.warn("Endpoint of wire and unloaded line segment do not match\n{}, {} vs {}, {}",
-                        part.getEndpoint1(), part.getEndpoint2(), owner.getEndpoint1(), owner.getEndpoint2());
-                remove();
-                return;
-            }
+    /**
+     * Rebind a line which has not entered the solver graph yet to the endpoint
+     * nodes currently indexed by the world network.
+     */
+    public void refreshDetachedEndpointNodes() {
+        if(getNetwork() != null)
+            throw new IllegalStateException("Cannot refresh endpoint nodes of a connected transmission line");
+        setNode1(endpoint1, global.holderOrPlaceholderNode(endpoint1));
+        setNode2(endpoint2, global.holderOrPlaceholderNode(endpoint2));
+    }
+
+    public boolean grabPart(@NotNull BaseWireEntity owner, WorldNetworks.PartId ownerId, TransmissionLinePart part) {
+        if(part.persistentOwnerId.equals(ownerId)) {
+            // WorldNetworks validates this part against the exact electrical
+            // endpoint pair passed by the physical owner before calling grab.
+            // That pair can differ from BaseWireEntity#getEndpointN for
+            // multi-conductor cords, so it must not be re-derived here.
+            part.refreshEndpointNodes();
+            var node1 = part.getNode1();
+            var node2 = part.getNode2();
             if(part.getEndpoint1().equals(endpoint1) && endpoint1.getNode(global.world) != node1) {
                 // Update node
                 setNode1(endpoint1.getNode(global.world));
@@ -203,7 +208,9 @@ public class TransmissionLine extends ElectricWire {
                 validateLine();
             if(ModdedConfigs.logsEnabled())
                 PowerGrid.LOGGER.debug("{}: Grabbed unloaded part of line, owner={}, between=({}, {})", this, owner, part.getNode1(), part.getNode2());
+            return true;
         }
+        return false;
     }
 
     public void addLastSegment(TransmissionLinePart wire) {
@@ -303,7 +310,7 @@ public class TransmissionLine extends ElectricWire {
             line2.setResistance(R2);
             var network = global.prepareForConnection(line2.endpoint1, line2.endpoint2);
             if(network != null)
-                network.addWire(line2);
+                global.addPreparedTransmissionLine(network, line2);
         } else {
             splitting = false;
             throw new IllegalStateException("Splitting failed for " + this);
@@ -383,6 +390,31 @@ public class TransmissionLine extends ElectricWire {
         optimizeNode(getNode2());
     }
 
+    /**
+     * Detach the derived transmission line without deleting its persisted physical
+     * segments. The server-side repair command uses this before assembling a fresh
+     * topology from those segments.
+     */
+    public void detachForRebuild() {
+        var affectedNetwork = getNetwork();
+        if(affectedNetwork != null)
+            super.remove();
+        if(global.globalGraph.getWires(getNode1(), getNode2()).contains(this))
+            global.globalGraph.disconnect(getNode1(), getNode2(), this);
+        setNetwork(null);
+
+        if(port1 != null) {
+            port1.remove();
+            port2.remove();
+            port1 = port2 = null;
+        }
+        for(var segment : segments) {
+            if(segment.getLine() == this)
+                segment.setLine(null);
+        }
+        global.scheduleIslandDiscovery(affectedNetwork);
+    }
+
     public boolean isPart(ElectricWire wire) {
         return segments.contains(wire);
     }
@@ -432,11 +464,12 @@ public class TransmissionLine extends ElectricWire {
             remove();
             return;
         }
-        if(!segments.contains(wire)) {
+        var segmentIndex = segments.indexOf(wire);
+        if(segmentIndex < 0) {
             PowerGrid.LOGGER.error("Wire is not part of this transmission line even though it thinks so");
             return;
         }
-        if (wire.getNode1() == node1) {
+        if (segmentIndex == 0) {
             // First segment
             PowerGrid.LOGGER.debug("{}: Removing first segment of transmission line", this);
             var removed = segments.remove(0);
@@ -455,7 +488,7 @@ public class TransmissionLine extends ElectricWire {
             optimizeNode(optiNode);
             if(ENABLE_VALIDATION)
                 validateLine();
-        } else if (wire.getNode2() == node2) {
+        } else if (segmentIndex == segments.size() - 1) {
             // Last segment
             if(ModdedConfigs.logsEnabled())
                 PowerGrid.LOGGER.debug("{}: Removing last segment of transmission line", this);

--- a/src/main/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionLinePart.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionLinePart.java
@@ -28,7 +28,6 @@ import org.patryk3211.powergrid.electricity.sim.node.IElectricNode;
 import org.patryk3211.powergrid.electricity.sim.node.OwnedFloatingNode;
 import org.patryk3211.powergrid.electricity.wire.BaseWireEntity;
 import org.patryk3211.powergrid.electricity.wire.IWireEndpoint;
-import org.patryk3211.powergrid.electricity.wire.WireEndpointType;
 
 import java.util.Objects;
 
@@ -37,23 +36,47 @@ public class TransmissionLinePart extends ElectricWire {
     private TransmissionLine line;
     @NotNull
     private final WorldNetworks global;
+    @NotNull
+    private final TransmissionConnectionEndpoints connectionEndpoints;
 
     @Nullable
     public BaseWireEntity owner;
     public final WorldNetworks.PartId persistentOwnerId;
     public ChunkPos lastKnownChunk;
 
-    private TransmissionLinePart(double resistance, @NotNull IWireEndpoint endpoint1, @NotNull IWireEndpoint endpoint2, WorldNetworks.PartId ownerId, ChunkPos lastKnownChunk, @NotNull WorldNetworks global) {
-        super(resistance, global.holderOrPlaceholderNode(endpoint1), global.holderOrPlaceholderNode(endpoint2));
+    private TransmissionLinePart(
+            double resistance,
+            @NotNull TransmissionConnectionEndpoints connectionEndpoints,
+            WorldNetworks.PartId ownerId,
+            ChunkPos lastKnownChunk,
+            @NotNull WorldNetworks global
+    ) {
+        super(
+                resistance,
+                global.holderOrPlaceholderNode(connectionEndpoints.endpoint1()),
+                global.holderOrPlaceholderNode(connectionEndpoints.endpoint2())
+        );
         this.global = global;
+        this.connectionEndpoints = connectionEndpoints;
         this.persistentOwnerId = ownerId;
         this.lastKnownChunk = lastKnownChunk;
         global.registerPart(persistentOwnerId, this);
     }
 
-    private TransmissionLinePart(double resistance, @NotNull IWireEndpoint endpoint1, @NotNull IWireEndpoint endpoint2, @NotNull BaseWireEntity owner, @NotNull WorldNetworks global, WorldNetworks.PartId id) {
-        super(resistance, global.holderOrPlaceholderNode(endpoint1), global.holderOrPlaceholderNode(endpoint2));
+    private TransmissionLinePart(
+            double resistance,
+            @NotNull TransmissionConnectionEndpoints connectionEndpoints,
+            @NotNull BaseWireEntity owner,
+            @NotNull WorldNetworks global,
+            WorldNetworks.PartId id
+    ) {
+        super(
+                resistance,
+                global.holderOrPlaceholderNode(connectionEndpoints.endpoint1()),
+                global.holderOrPlaceholderNode(connectionEndpoints.endpoint2())
+        );
         this.global = global;
+        this.connectionEndpoints = connectionEndpoints;
         this.owner = owner;
         this.persistentOwnerId = id;
         this.lastKnownChunk = new ChunkPos(owner.blockPosition());
@@ -68,19 +91,30 @@ public class TransmissionLinePart extends ElectricWire {
             ownerId = new WorldNetworks.SimpleId(tag.getUUID("Owner"));
         }
         var resistance = tag.getDouble("Resistance");
-        var endpoint1 = WireEndpointType.deserialize(tag.getCompound("Node1"));
-        var endpoint2 = WireEndpointType.deserialize(tag.getCompound("Node2"));
+        var connectionEndpoints = TransmissionConnectionEndpoints.fromNbt(tag);
         var lastKnownChunk = new ChunkPos(tag.getInt("X"), tag.getInt("Z"));
         var part = global.getPart(ownerId);
         if(part == null)
-            return new TransmissionLinePart(resistance, endpoint1, endpoint2, ownerId, lastKnownChunk, global);
+            return new TransmissionLinePart(
+                    resistance,
+                    connectionEndpoints,
+                    ownerId,
+                    lastKnownChunk,
+                    global
+            );
         return part;
     }
 
     public static TransmissionLinePart uniquePart(double resistance, @NotNull IWireEndpoint endpoint1, @NotNull IWireEndpoint endpoint2, BaseWireEntity owner, @NotNull WorldNetworks global, WorldNetworks.PartId id) {
         var part = global.getPart(id);
         if(part == null)
-            return new TransmissionLinePart(resistance, endpoint1, endpoint2, owner, global, id);
+            return new TransmissionLinePart(
+                    resistance,
+                    new TransmissionConnectionEndpoints(endpoint1, endpoint2),
+                    owner,
+                    global,
+                    id
+            );
         return part;
     }
 
@@ -116,6 +150,24 @@ public class TransmissionLinePart extends ElectricWire {
         return getNode2().endpoint;
     }
 
+    /**
+     * Return the physical endpoint recorded by the owning wire entity.
+     * It can differ from the canonical endpoint returned by {@link #getEndpoint1()}.
+     */
+    @NotNull
+    public IWireEndpoint getConnectionEndpoint1() {
+        return connectionEndpoints.endpoint1();
+    }
+
+    /**
+     * Return the physical endpoint recorded by the owning wire entity.
+     * It can differ from the canonical endpoint returned by {@link #getEndpoint2()}.
+     */
+    @NotNull
+    public IWireEndpoint getConnectionEndpoint2() {
+        return connectionEndpoints.endpoint2();
+    }
+
     @Nullable
     public TransmissionLine getLine() {
         return line;
@@ -134,14 +186,36 @@ public class TransmissionLinePart extends ElectricWire {
         owner = null;
     }
 
-    public void grab(BaseWireEntity forEntity, WorldNetworks.PartId id) {
+    public boolean grab(BaseWireEntity forEntity, WorldNetworks.PartId id) {
         if(persistentOwnerId.equals(id)) {
             owner = forEntity;
-            if (line != null)
-                line.grabPart(forEntity, this);
+            if(line != null && !line.grabPart(forEntity, id, this)) {
+                owner = null;
+                return false;
+            }
+            return true;
         } else {
             PowerGrid.LOGGER.warn("Entity tried to grab a part which it does not own, part: {}, entity: {}", this, forEntity);
+            return false;
         }
+    }
+
+    public boolean endpointsMatch(IWireEndpoint endpoint1, IWireEndpoint endpoint2) {
+        return connectionEndpoints.matches(endpoint1, endpoint2);
+    }
+
+    public static boolean sameEndpoints(
+            IWireEndpoint stored1,
+            IWireEndpoint stored2,
+            IWireEndpoint current1,
+            IWireEndpoint current2
+    ) {
+        return TransmissionConnectionEndpoints.sameEndpoints(
+                stored1,
+                stored2,
+                current1,
+                current2
+        );
     }
 
     // Transmission line part can NEVER be directly in a network.
@@ -182,13 +256,19 @@ public class TransmissionLinePart extends ElectricWire {
 
     @Override
     public String toString() {
-        return String.format("LinePart[id=%s, %s, %s]", persistentOwnerId, getEndpoint1(), getEndpoint2());
+        return String.format(
+                "LinePart[id=%s, connections=(%s, %s), nodes=(%s, %s)]",
+                persistentOwnerId,
+                getConnectionEndpoint1(),
+                getConnectionEndpoint2(),
+                getNode1(),
+                getNode2()
+        );
     }
 
     public CompoundTag toNbt() {
         var tag = new CompoundTag();
-        tag.put("Node1", getEndpoint1().serialize());
-        tag.put("Node2", getEndpoint2().serialize());
+        connectionEndpoints.writeToNbt(tag);
         if(persistentOwnerId instanceof WorldNetworks.SimpleId id) {
             tag.putUUID("Owner", id.id());
         } else if(persistentOwnerId instanceof WorldNetworks.ComplexId id) {
@@ -204,14 +284,14 @@ public class TransmissionLinePart extends ElectricWire {
     }
 
     public void refreshEndpointNodes() {
-        var node1 = getEndpoint1().getNode(global.world);
+        var node1 = global.holderOrPlaceholderNode(getConnectionEndpoint1());
         if(this.node1 != node1 && node1 != null) {
-            global.addAndMigrateNode(getNode1().endpoint, node1);
+            global.movePartMap(getNode1(), node1, this);
             setNode1(node1);
         }
-        var node2 = getEndpoint2().getNode(global.world);
+        var node2 = global.holderOrPlaceholderNode(getConnectionEndpoint2());
         if(this.node2 != node2 && node2 != null) {
-            global.addAndMigrateNode(getNode2().endpoint, node2);
+            global.movePartMap(getNode2(), node2, this);
             setNode2(node2);
         }
     }

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/BaseWireEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/BaseWireEntity.java
@@ -20,11 +20,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -302,14 +305,20 @@ public abstract class BaseWireEntity extends Entity implements EntityDataS2CPack
     }
 
     @Override
+    public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity entity) {
+        // The official client retains one entity-data packet when it arrives
+        // before the matching spawn packet. Send the complete state first so
+        // it replaces any stale render-only packet for a reused entity id.
+        ModdedPackets.sendToClientsTracking(createExtraDataPacket(), this);
+        return super.getAddEntityPacket(entity);
+    }
+
+    @Override
     public void startSeenByPlayer(ServerPlayer player) {
         super.startSeenByPlayer(player);
-        // Minecraft calls this only after its entity-spawn bundle has been sent
-        // to this player. The full packet initializes material and endpoint
-        // state. Hanging wires then send their server-calculated terminal
-        // geometry as a second, existing-format packet so render setup never
-        // depends on client chunk/block-entity readiness.
-        ModdedPackets.sendToClient(createExtraDataPacket(), player);
+        // ServerEntity calls this after queuing the entity-spawn bundle. The
+        // pre-spawn full packet is ordered to initialize material and endpoint
+        // state before render-only geometry is applied after entity join.
         sendTrackingRenderData(player);
     }
 

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/BaseWireEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/BaseWireEntity.java
@@ -20,15 +20,13 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
@@ -40,6 +38,7 @@ import net.minecraft.world.item.DyeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.material.PushReaction;
 import org.jetbrains.annotations.NotNull;
@@ -49,6 +48,7 @@ import org.patryk3211.powergrid.collections.ModdedConfigs;
 import org.patryk3211.powergrid.collections.ModdedItems;
 import org.patryk3211.powergrid.collections.ModdedPackets;
 import org.patryk3211.powergrid.collections.ModdedSoundEvents;
+import org.patryk3211.powergrid.electricity.GlobalElectricNetworks;
 import org.patryk3211.powergrid.electricity.base.ThermalBehaviour;
 import org.patryk3211.powergrid.electricity.sim.DebugItem;
 import org.patryk3211.powergrid.electricity.wire.registry.WireItemEntry;
@@ -293,11 +293,24 @@ public abstract class BaseWireEntity extends Entity implements EntityDataS2CPack
         ModdedPackets.sendToClientsTracking(createExtraDataPacket(), this);
     }
 
+    /**
+     * Sends render-only state which cannot be reconstructed reliably from a
+     * client's independently loaded block entities. Most wire types need only
+     * the complete persisted-data packet.
+     */
+    protected void sendTrackingRenderData(ServerPlayer player) {
+    }
+
     @Override
-    public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity entity) {
-        var extra = createExtraDataPacket();
-        ModdedPackets.sendToClientsTracking(extra, this);
-        return super.getAddEntityPacket(entity);
+    public void startSeenByPlayer(ServerPlayer player) {
+        super.startSeenByPlayer(player);
+        // Minecraft calls this only after its entity-spawn bundle has been sent
+        // to this player. The full packet initializes material and endpoint
+        // state. Hanging wires then send their server-calculated terminal
+        // geometry as a second, existing-format packet so render setup never
+        // depends on client chunk/block-entity readiness.
+        ModdedPackets.sendToClient(createExtraDataPacket(), player);
+        sendTrackingRenderData(player);
     }
 
     @Override
@@ -527,7 +540,11 @@ public abstract class BaseWireEntity extends Entity implements EntityDataS2CPack
     public abstract void unloaded();
 
     public static void entityUnload(Entity entity, ServerLevel world) {
-        if(entity instanceof BaseWireEntity wire)
+        if(entity instanceof BaseWireEntity wire) {
             wire.unloaded();
+            var networks = GlobalElectricNetworks.getWorldNetworks((LevelAccessor) world);
+            if(networks != null)
+                networks.unloadPartsOwnedBy(wire);
+        }
     }
 }

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/BaseWireEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/BaseWireEntity.java
@@ -20,14 +20,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -87,6 +84,8 @@ public abstract class BaseWireEntity extends Entity implements EntityDataS2CPack
     protected Float resistanceOverride = null;
 
     protected boolean sublevelMove;
+    private final WireTrackingRecipients<ServerPlayer> establishedTrackingPlayers =
+            new WireTrackingRecipients<>();
 
     public BaseWireEntity(EntityType<?> type, Level world) {
         super(type, world);
@@ -304,22 +303,27 @@ public abstract class BaseWireEntity extends Entity implements EntityDataS2CPack
     protected void sendTrackingRenderData(ServerPlayer player) {
     }
 
-    @Override
-    public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity entity) {
-        // The official client retains one entity-data packet when it arrives
-        // before the matching spawn packet. Send the complete state first so
-        // it replaces any stale render-only packet for a reused entity id.
-        ModdedPackets.sendToClientsTracking(createExtraDataPacket(), this);
-        return super.getAddEntityPacket(entity);
+    protected void sendRenderDataToEstablishedTrackingPlayers(EntityDataS2CPacket packet) {
+        establishedTrackingPlayers.forEach(player -> ModdedPackets.sendToClient(packet, player));
     }
 
     @Override
     public void startSeenByPlayer(ServerPlayer player) {
         super.startSeenByPlayer(player);
-        // ServerEntity calls this after queuing the entity-spawn bundle. The
-        // pre-spawn full packet is ordered to initialize material and endpoint
-        // state before render-only geometry is applied after entity join.
+        // ServerEntity calls this after sending the entity-spawn bundle. Send
+        // complete material and endpoint state before render-only geometry,
+        // then admit the player to normal geometry broadcasts.
+        ModdedPackets.sendToClient(createExtraDataPacket(), player);
         sendTrackingRenderData(player);
+        establishedTrackingPlayers.start(player);
+    }
+
+    @Override
+    public void stopSeenByPlayer(ServerPlayer player) {
+        // Stop render-only broadcasts before Minecraft queues the removal
+        // packet so geometry cannot outlive this tracking session.
+        establishedTrackingPlayers.stop(player);
+        super.stopSeenByPlayer(player);
     }
 
     @Override

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/BlockWireEndpoint.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/BlockWireEndpoint.java
@@ -129,6 +129,21 @@ public class BlockWireEndpoint implements IWireEndpoint {
     }
 
     @Override
+    public boolean isStructurallyValid(Level world) {
+        if(pos == null
+                || !world.hasChunk(
+                        SectionPos.blockToSectionCoord(pos.getX()),
+                        SectionPos.blockToSectionCoord(pos.getZ())
+                )) {
+            return false;
+        }
+        var electric = getElectricBlock(world);
+        if(electric == null || terminal < 0 || terminal >= electric.terminalCount())
+            return false;
+        return electric.terminal(world.getBlockState(pos), terminal) != null;
+    }
+
+    @Override
     public <T extends BaseWireEntity> boolean canAcceptType(Class<T> clazz) {
         return WireEntity.class.isAssignableFrom(clazz);
     }

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/HangingWireEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/HangingWireEntity.java
@@ -21,9 +21,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.FloatTag;
-import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -258,6 +257,23 @@ public class HangingWireEntity extends WireEntity implements IComplexRaycast {
     }
 
     @Override
+    protected void sendTrackingRenderData(ServerPlayer player) {
+        if(terminalPos1 == null || terminalPos2 == null)
+            return;
+        ModdedPackets.sendToClient(
+                new EntityDataS2CPacket(
+                        this,
+                        WireRenderSync.terminalGeometry(
+                                terminalPos1,
+                                terminalPos2,
+                                isDynamic
+                        )
+                ),
+                player
+        );
+    }
+
+    @Override
     protected void addAdditionalSaveData(CompoundTag nbt) {
         super.addAdditionalSaveData(nbt);
         nbt.putFloat("PlacedLength", placedLength);
@@ -408,17 +424,14 @@ public class HangingWireEntity extends WireEntity implements IComplexRaycast {
                 // the update method would have to go into the tick function
                 // and that is probably slower.
 
-                var tag = new CompoundTag();
-                var list = new ListTag();
-                list.add(FloatTag.valueOf((float) terminalPos1.x));
-                list.add(FloatTag.valueOf((float) terminalPos1.y));
-                list.add(FloatTag.valueOf((float) terminalPos1.z));
-                list.add(FloatTag.valueOf((float) terminalPos2.x));
-                list.add(FloatTag.valueOf((float) terminalPos2.y));
-                list.add(FloatTag.valueOf((float) terminalPos2.z));
-                tag.putBoolean("D", isDynamic);
-                tag.put("V", list);
-                var packet = new EntityDataS2CPacket(this, tag);
+                var packet = new EntityDataS2CPacket(
+                        this,
+                        WireRenderSync.terminalGeometry(
+                                terminalPos1,
+                                terminalPos2,
+                                isDynamic
+                        )
+                );
                 ModdedPackets.sendToClientsTracking(packet, this);
             }
         }

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/HangingWireEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/HangingWireEntity.java
@@ -246,6 +246,8 @@ public class HangingWireEntity extends WireEntity implements IComplexRaycast {
     @Override
     public void onEntityDataPacket(CompoundTag data) {
         if(data.contains("V")) {
+            if(!WireRenderSync.canApplyTerminalGeometry(data, getWireEntry() != null))
+                return;
             var list = data.getList("V", Tag.TAG_FLOAT);
             terminalPos1 = new Vec3(list.getFloat(0), list.getFloat(1), list.getFloat(2));
             terminalPos2 = new Vec3(list.getFloat(3), list.getFloat(4), list.getFloat(5));
@@ -432,7 +434,7 @@ public class HangingWireEntity extends WireEntity implements IComplexRaycast {
                                 isDynamic
                         )
                 );
-                ModdedPackets.sendToClientsTracking(packet, this);
+                sendRenderDataToEstablishedTrackingPlayers(packet);
             }
         }
     }

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/IWireEndpoint.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/IWireEndpoint.java
@@ -39,6 +39,17 @@ public interface IWireEndpoint {
         return true;
     }
 
+    /**
+     * Checks whether the physical endpoint still exists independently of
+     * runtime electrical-behaviour initialization.
+     *
+     * <p>Most endpoint types have no separate late-initialization phase, so
+     * their normal validity is also their structural validity.</p>
+     */
+    default boolean isStructurallyValid(Level world) {
+        return isValid(world);
+    }
+
     default <T extends BaseWireEntity> boolean canAcceptType(Class<T> clazz) {
         return false;
     }

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/WireRenderSync.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/WireRenderSync.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity.wire;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.FloatTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Builds the terminal-geometry payload already understood by official
+ * Power Grid 0.5.5.1 clients.
+ */
+public final class WireRenderSync {
+    private WireRenderSync() {
+    }
+
+    public static CompoundTag terminalGeometry(Vec3 terminal1, Vec3 terminal2, boolean dynamic) {
+        var tag = new CompoundTag();
+        var positions = new ListTag();
+        positions.add(FloatTag.valueOf((float) terminal1.x));
+        positions.add(FloatTag.valueOf((float) terminal1.y));
+        positions.add(FloatTag.valueOf((float) terminal1.z));
+        positions.add(FloatTag.valueOf((float) terminal2.x));
+        positions.add(FloatTag.valueOf((float) terminal2.y));
+        positions.add(FloatTag.valueOf((float) terminal2.z));
+        tag.putBoolean("D", dynamic);
+        tag.put("V", positions);
+        return tag;
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/WireRenderSync.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/WireRenderSync.java
@@ -28,6 +28,10 @@ public final class WireRenderSync {
     private WireRenderSync() {
     }
 
+    public static boolean canApplyTerminalGeometry(CompoundTag data, boolean materialReady) {
+        return !data.contains("V") || materialReady;
+    }
+
     public static CompoundTag terminalGeometry(Vec3 terminal1, Vec3 terminal2, boolean dynamic) {
         var tag = new CompoundTag();
         var positions = new ListTag();

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/WireTrackingRecipients.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/WireTrackingRecipients.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity.wire;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.function.Consumer;
+
+final class WireTrackingRecipients<T> {
+    private final Set<T> recipients = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    void start(T recipient) {
+        recipients.add(recipient);
+    }
+
+    void stop(T recipient) {
+        recipients.remove(recipient);
+    }
+
+    void forEach(Consumer<T> action) {
+        recipients.forEach(action);
+    }
+}

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/powercord/CordEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/powercord/CordEntity.java
@@ -21,9 +21,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.FloatTag;
-import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -45,6 +44,7 @@ import org.patryk3211.powergrid.electricity.wire.BaseWireEntity;
 import org.patryk3211.powergrid.electricity.wire.CurveParameters;
 import org.patryk3211.powergrid.electricity.wire.IWire;
 import org.patryk3211.powergrid.electricity.wire.IWireEndpoint;
+import org.patryk3211.powergrid.electricity.wire.WireRenderSync;
 import org.patryk3211.powergrid.network.packets.EntityDataS2CPacket;
 import org.patryk3211.powergrid.utility.IComplexRaycast;
 
@@ -244,17 +244,14 @@ public class CordEntity extends BaseWireEntity implements IComplexRaycast {
                 // the update method would have to go into the tick function
                 // and that is probably slower.
 
-                var tag = new CompoundTag();
-                var list = new ListTag();
-                list.add(FloatTag.valueOf((float) terminalPos1.x));
-                list.add(FloatTag.valueOf((float) terminalPos1.y));
-                list.add(FloatTag.valueOf((float) terminalPos1.z));
-                list.add(FloatTag.valueOf((float) terminalPos2.x));
-                list.add(FloatTag.valueOf((float) terminalPos2.y));
-                list.add(FloatTag.valueOf((float) terminalPos2.z));
-                tag.putBoolean("D", isDynamic);
-                tag.put("V", list);
-                var packet = new EntityDataS2CPacket(this, tag);
+                var packet = new EntityDataS2CPacket(
+                        this,
+                        WireRenderSync.terminalGeometry(
+                                terminalPos1,
+                                terminalPos2,
+                                isDynamic
+                        )
+                );
                 ModdedPackets.sendToClientsTracking(packet, this);
             }
         }
@@ -356,6 +353,23 @@ public class CordEntity extends BaseWireEntity implements IComplexRaycast {
         } else {
             super.onEntityDataPacket(data);
         }
+    }
+
+    @Override
+    protected void sendTrackingRenderData(ServerPlayer player) {
+        if(terminalPos1 == null || terminalPos2 == null)
+            return;
+        ModdedPackets.sendToClient(
+                new EntityDataS2CPacket(
+                        this,
+                        WireRenderSync.terminalGeometry(
+                                terminalPos1,
+                                terminalPos2,
+                                isDynamic
+                        )
+                ),
+                player
+        );
     }
 
     @Override

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/powercord/CordEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/powercord/CordEntity.java
@@ -252,7 +252,7 @@ public class CordEntity extends BaseWireEntity implements IComplexRaycast {
                                 isDynamic
                         )
                 );
-                ModdedPackets.sendToClientsTracking(packet, this);
+                sendRenderDataToEstablishedTrackingPlayers(packet);
             }
         }
     }
@@ -345,6 +345,8 @@ public class CordEntity extends BaseWireEntity implements IComplexRaycast {
     @Override
     public void onEntityDataPacket(CompoundTag data) {
         if(data.contains("V")) {
+            if(!WireRenderSync.canApplyTerminalGeometry(data, getWireEntry() != null))
+                return;
             var list = data.getList("V", Tag.TAG_FLOAT);
             terminalPos1 = new Vec3(list.getFloat(0), list.getFloat(1), list.getFloat(2));
             terminalPos2 = new Vec3(list.getFloat(3), list.getFloat(4), list.getFloat(5));

--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/powercord/ICordEndpoint.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/powercord/ICordEndpoint.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.electricity.wire.powercord;
 
+import net.minecraft.world.level.Level;
 import org.patryk3211.powergrid.electricity.wire.BaseWireEntity;
 import org.patryk3211.powergrid.electricity.wire.IWireEndpoint;
 
@@ -25,6 +26,16 @@ public interface ICordEndpoint extends IWireEndpoint {
     @Override
     default <T extends BaseWireEntity> boolean canAcceptType(Class<T> clazz) {
         return CordEntity.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    default boolean isStructurallyValid(Level world) {
+        var endpoint1 = getEndpoint1();
+        var endpoint2 = getEndpoint2();
+        return endpoint1 != null
+                && endpoint1.isStructurallyValid(world)
+                && endpoint2 != null
+                && endpoint2.isStructurallyValid(world);
     }
 
     @Override

--- a/src/main/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacket.java
+++ b/src/main/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacket.java
@@ -40,8 +40,16 @@ public class EntityDataS2CPacket implements S2CPacket {
         data = buffer.readNbt();
     }
 
+    static CompoundTag takeDeferredData(int entityId) {
+        return DEFERRED_DATA.remove(entityId);
+    }
+
+    static void deferData(int entityId, CompoundTag data) {
+        DEFERRED_DATA.put(entityId, data);
+    }
+
     public static void clientEntityAdded(Entity entity) {
-        var tag = DEFERRED_DATA.remove(entity.getId());
+        var tag = takeDeferredData(entity.getId());
         if(tag == null)
             return;
         if(entity instanceof IConsumer consumer)
@@ -59,7 +67,7 @@ public class EntityDataS2CPacket implements S2CPacket {
         var world = ClientSideAccess.world();
         var entity = world.getEntity(entityId);
         if(entity == null) {
-            DEFERRED_DATA.put(entityId, data);
+            deferData(entityId, data);
             return;
         }
         if(entity instanceof IConsumer consumer)

--- a/src/main/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacket.java
+++ b/src/main/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacket.java
@@ -44,8 +44,18 @@ public class EntityDataS2CPacket implements S2CPacket {
         return DEFERRED_DATA.remove(entityId);
     }
 
+    static CompoundTag selectDeferredData(CompoundTag existing, CompoundTag incoming) {
+        if(existing != null && existing.contains("Item") && !incoming.contains("Item"))
+            return existing;
+        return incoming;
+    }
+
     static void deferData(int entityId, CompoundTag data) {
-        DEFERRED_DATA.put(entityId, data);
+        DEFERRED_DATA.compute(entityId, ($, existing) -> selectDeferredData(existing, data));
+    }
+
+    public static void clearDeferredData() {
+        DEFERRED_DATA.clear();
     }
 
     public static void clientEntityAdded(Entity entity) {

--- a/src/main/resources/assets/powergrid/lang/default/messages.json
+++ b/src/main/resources/assets/powergrid/lang/default/messages.json
@@ -31,6 +31,15 @@
   "powergrid.message.config_reset_ok": "Configuration successfully reset",
   "powergrid.message.config_ignore_ok": "This message will not be shown again",
 
+  "powergrid.command.rebuild.start": "Verified rebuild started: %1$s parts, %2$s unique chunks in %3$s batches. Chunks will be released progressively.",
+  "powergrid.command.rebuild.cooldown": "Wait %1$s seconds before rebuilding the network again.",
+  "powergrid.command.rebuild.running": "A verified rebuild is already running in this dimension.",
+  "powergrid.command.rebuild.too_many_chunks": "Rebuild refused: the network needs %1$s chunks, above the safety limit of %2$s.",
+  "powergrid.command.rebuild.success": "Network verified: %1$s parts, %2$s chunks, %3$s records refreshed, %4$s recovered, %5$s removed, %6$s final lines, %7$s ms.",
+  "powergrid.command.rebuild.partial": "Partial verified rebuild: %1$s parts unresolved and %2$s parts queued for automatic retry (at most %3$s attempts). Check the log.",
+  "powergrid.command.rebuild.failed": "Rebuild failed after %1$s attempts. Temporary chunks were released; check the log.",
+  "powergrid.command.rebuild.no_level": "The dimension is not available yet. Wait for the server to finish loading.",
+
   "death.attack.overloaded_machine": "%s was killed by an overloaded %s",
   "death.attack.overloaded_machine.player": "%s was killed by an overloaded %s whilst trying to escape %s",
   "death.attack.zap": "%1$s was zapped by %2$s",

--- a/src/main/resources/assets/powergrid/lang/it_it.json
+++ b/src/main/resources/assets/powergrid/lang/it_it.json
@@ -1,4 +1,12 @@
 {
+  "powergrid.command.rebuild.cooldown": "Attendi %1$s secondi prima di ricostruire nuovamente la rete.",
+  "powergrid.command.rebuild.failed": "Ricostruzione non riuscita dopo %1$s tentativi. I chunk temporanei sono stati rilasciati; controlla il log.",
+  "powergrid.command.rebuild.no_level": "La dimensione non \u00e8 ancora disponibile. Attendi il caricamento completo del server.",
+  "powergrid.command.rebuild.partial": "Ricostruzione verificata parziale: %1$s tratti non risolti e %2$s tratti in retry automatico (massimo %3$s tentativi). Controlla il log.",
+  "powergrid.command.rebuild.running": "Una ricostruzione verificata \u00e8 gi\u00e0 in corso in questa dimensione.",
+  "powergrid.command.rebuild.start": "Ricostruzione verificata avviata: %1$s tratti, %2$s chunk unici in %3$s gruppi. I chunk saranno rilasciati progressivamente.",
+  "powergrid.command.rebuild.success": "Rete verificata: %1$s tratti, %2$s chunk, %3$s registrazioni ricostruite, %4$s recuperate, %5$s rimosse, %6$s linee finali, %7$s ms.",
+  "powergrid.command.rebuild.too_many_chunks": "Ricostruzione rifiutata: la rete richiede %1$s chunk, oltre il limite di sicurezza di %2$s.",
   "block.powergrid.acid": "Acido",
   "block.powergrid.alarm_bell": "Campanello d'Allarme",
   "block.powergrid.andesite_encased_crt": "CRT incassato in andesite",

--- a/src/test/java/org/patryk3211/powergrid/commands/RebuildCooldownTests.java
+++ b/src/test/java/org/patryk3211/powergrid/commands/RebuildCooldownTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.commands;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RebuildCooldownTests {
+    @Test
+    void cooldownIsIndependentPerDimensionAndExpires() {
+        var limiter = new RebuildCooldown<Object>(1200);
+        var overworld = new Object();
+        var nether = new Object();
+
+        Assertions.assertTrue(limiter.tryAcquire(overworld, 100));
+        Assertions.assertFalse(limiter.tryAcquire(overworld, 100));
+        Assertions.assertEquals(1200, limiter.remainingTicks(overworld, 100));
+
+        Assertions.assertTrue(limiter.tryAcquire(nether, 100));
+        Assertions.assertEquals(1, limiter.remainingTicks(overworld, 1299));
+        Assertions.assertTrue(limiter.tryAcquire(overworld, 1300));
+    }
+}

--- a/src/test/java/org/patryk3211/powergrid/electricity/RebuildBatchPlannerTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/RebuildBatchPlannerTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class RebuildBatchPlannerTests {
+    @Test
+    void ownerAndEndpointChunksStayInTheSameBoundedBatch() {
+        var units = List.of(
+                new RebuildBatchPlanner.Unit<>("part-a", Set.of(1, 2)),
+                new RebuildBatchPlanner.Unit<>("part-b", Set.of(2, 3)),
+                new RebuildBatchPlanner.Unit<>("part-c", Set.of(3, 4))
+        );
+
+        var batches = RebuildBatchPlanner.plan(units, 3);
+
+        Assertions.assertEquals(2, batches.size());
+        Assertions.assertEquals(List.of("part-a", "part-b"), batches.get(0).keys());
+        Assertions.assertEquals(Set.of(1, 2, 3), batches.get(0).required());
+        Assertions.assertEquals(List.of("part-c"), batches.get(1).keys());
+        Assertions.assertEquals(Set.of(3, 4), batches.get(1).required());
+        Assertions.assertTrue(batches.stream().allMatch(batch -> batch.required().size() <= 3));
+    }
+
+    @Test
+    void aSingleOversizedPhysicalPartIsRejected() {
+        var units = List.of(
+                new RebuildBatchPlanner.Unit<>("part-a", Set.of(1, 2, 3))
+        );
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> RebuildBatchPlanner.plan(units, 2)
+        );
+    }
+}

--- a/src/test/java/org/patryk3211/powergrid/electricity/RetryBudgetTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/RetryBudgetTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity;
+
+import net.minecraft.core.BlockPos;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.patryk3211.powergrid.electricity.wire.BlockWireEndpoint;
+import org.patryk3211.powergrid.electricity.wire.powercord.SplitCordEndpoint;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class RetryBudgetTests {
+    @Test
+    void automaticRetryBudgetStopsAfterThreeAttempts() {
+        var budget = new RetryBudget(WorldNetworks.MAX_AUTOMATIC_REBUILD_RETRIES);
+
+        Assertions.assertTrue(budget.tryAcquire());
+        Assertions.assertTrue(budget.tryAcquire());
+        Assertions.assertTrue(budget.tryAcquire());
+        Assertions.assertFalse(budget.tryAcquire());
+
+        Assertions.assertTrue(budget.exhausted());
+        Assertions.assertEquals(3, budget.attempts());
+        Assertions.assertEquals(0, budget.remaining());
+    }
+
+    @Test
+    void automaticRetryBudgetRejectsInvalidLimits() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new RetryBudget(0));
+    }
+
+    @Test
+    void physicalRegistrationRefreshHasThreeTotalAttempts() {
+        var budget = new RetryBudget(
+                TransmissionNetworkRebuildJob.MAX_PHYSICAL_REGISTRATION_ATTEMPTS
+        );
+
+        Assertions.assertTrue(budget.tryAcquire());
+        Assertions.assertTrue(budget.tryAcquire());
+        Assertions.assertTrue(budget.tryAcquire());
+        Assertions.assertFalse(budget.tryAcquire());
+        Assertions.assertEquals(3, budget.attempts());
+    }
+
+    @Test
+    void physicalRegistrationRefreshWaitsForBothValidEndpoints() {
+        Assertions.assertTrue(TransmissionNetworkRebuildJob.registrationReady(
+                true, true, true, true, true
+        ));
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.registrationReady(
+                true, true, true, true, false
+        ));
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.registrationReady(
+                true, false, false, true, true
+        ));
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.registrationReady(
+                false, true, true, true, true
+        ));
+    }
+
+    @Test
+    void startupCanRetainMatchingPhysicalRegistrationBeforeRuntimeBehaviourIsReady() {
+        Assertions.assertTrue(TransmissionNetworkRebuildJob.canRetainPersistedRegistration(
+                true, true, true, true, true
+        ));
+
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.canRetainPersistedRegistration(
+                false, true, true, true, true
+        ));
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.canRetainPersistedRegistration(
+                true, false, true, true, true
+        ));
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.canRetainPersistedRegistration(
+                true, true, false, true, true
+        ));
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.canRetainPersistedRegistration(
+                true, true, true, false, true
+        ));
+        Assertions.assertFalse(TransmissionNetworkRebuildJob.canRetainPersistedRegistration(
+                true, true, true, true, false
+        ));
+    }
+
+    @Test
+    void cordRegistrationUsesThePhysicalEndpointForItsConductor() {
+        var endpoint0 = new BlockWireEndpoint(new BlockPos(1, 2, 3), 0);
+        var endpoint1 = new BlockWireEndpoint(new BlockPos(1, 2, 3), 1);
+        var cordEndpoint = new SplitCordEndpoint(endpoint0, endpoint1);
+        var ownerId = UUID.randomUUID();
+
+        Assertions.assertSame(
+                endpoint0,
+                TransmissionNetworkRebuildJob.connectionEndpointForPart(
+                        cordEndpoint,
+                        new WorldNetworks.ComplexId(ownerId, 0)
+                )
+        );
+        Assertions.assertSame(
+                endpoint1,
+                TransmissionNetworkRebuildJob.connectionEndpointForPart(
+                        cordEndpoint,
+                        new WorldNetworks.ComplexId(ownerId, 1)
+                )
+        );
+        Assertions.assertNull(
+                TransmissionNetworkRebuildJob.connectionEndpointForPart(
+                        cordEndpoint,
+                        new WorldNetworks.ComplexId(ownerId, 2)
+                )
+        );
+    }
+
+    @Test
+    void postIsolationSettlementReconcilesOnlyRegistrationsThatReturned() {
+        var unresolved = new HashSet<>(Set.of("ready-a", "missing", "ready-b"));
+        var verified = new HashSet<>(Set.of("already-verified"));
+
+        var recovered = TransmissionNetworkRebuildJob.reconcileRecoveredRegistrations(
+                unresolved,
+                verified,
+                id -> id.startsWith("ready-")
+        );
+
+        Assertions.assertEquals(2, recovered);
+        Assertions.assertEquals(Set.of("missing"), unresolved);
+        Assertions.assertEquals(
+                Set.of("already-verified", "ready-a", "ready-b"),
+                verified
+        );
+    }
+}

--- a/src/test/java/org/patryk3211/powergrid/electricity/TransmissionLineRecoveryTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/TransmissionLineRecoveryTests.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+import org.patryk3211.powergrid.electricity.sim.node.OwnedFloatingNode;
+import org.patryk3211.powergrid.electricity.sim.DummyElectricalNetwork;
+import org.patryk3211.powergrid.electricity.sim.ElectricWire;
+import org.patryk3211.powergrid.electricity.sim.NetworkGraph;
+import org.patryk3211.powergrid.electricity.sim.special.TransmissionLine;
+import org.patryk3211.powergrid.electricity.sim.special.TransmissionLinePart;
+import org.patryk3211.powergrid.electricity.wire.BaseWireEntity;
+import org.patryk3211.powergrid.electricity.wire.BlockWireEndpoint;
+import org.patryk3211.powergrid.electricity.wire.ImaginaryWireEndpoint;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class TransmissionLineRecoveryTests {
+    @Test
+    void verifiedScanBlocksTopologyResolutionUntilFinalAssembly() {
+        Assertions.assertTrue(WorldNetworks.transmissionTopologyResolutionAllowed(false, false));
+        Assertions.assertFalse(WorldNetworks.transmissionTopologyResolutionAllowed(true, false));
+        Assertions.assertTrue(WorldNetworks.transmissionTopologyResolutionAllowed(true, true));
+    }
+
+    @Test
+    void ordinaryEndpointBindingCannotReenterTransmissionLineSplitting() {
+        Assertions.assertFalse(WorldNetworks.shouldSplitAfterNodeBinding(
+                WorldNetworks.NodeBindingMode.BIND_ONLY,
+                true
+        ));
+        Assertions.assertFalse(WorldNetworks.shouldSplitAfterNodeBinding(
+                WorldNetworks.NodeBindingMode.BIND_AND_SPLIT,
+                false
+        ));
+        Assertions.assertTrue(WorldNetworks.shouldSplitAfterNodeBinding(
+                WorldNetworks.NodeBindingMode.BIND_AND_SPLIT,
+                true
+        ));
+    }
+
+    @Test
+    void missingPartsWaitForTheEntityLoadGracePeriod() {
+        var check = new WorldNetworks.CheckChunk();
+
+        for(int tick = 0; tick < WorldNetworks.ENTITY_LOAD_GRACE_TICKS; ++tick) {
+            Assertions.assertFalse(check.advanceEntityLoadCheck());
+        }
+        Assertions.assertTrue(check.advanceEntityLoadCheck());
+
+        check.resetTicks();
+        Assertions.assertFalse(check.advanceEntityLoadCheck());
+    }
+
+    @Test
+    void transmissionLineGrabUsesTheCompletePartId() throws NoSuchMethodException {
+        var entityId = UUID.randomUUID();
+        var simpleId = new WorldNetworks.SimpleId(entityId);
+        var firstComplexPart = new WorldNetworks.ComplexId(entityId, 0);
+        var secondComplexPart = new WorldNetworks.ComplexId(entityId, 1);
+
+        Assertions.assertEquals(simpleId, new WorldNetworks.SimpleId(entityId));
+        Assertions.assertNotEquals(simpleId, entityId);
+        Assertions.assertNotEquals(firstComplexPart, secondComplexPart);
+
+        Assertions.assertNotNull(TransmissionLine.class.getDeclaredMethod(
+                "grabPart",
+                BaseWireEntity.class,
+                WorldNetworks.PartId.class,
+                TransmissionLinePart.class
+        ));
+    }
+
+    @Test
+    void rebuiltTransmissionLinesAcceptAlreadyResolvedNonNullNodes() throws NoSuchMethodException {
+        Assertions.assertNotNull(TransmissionLine.class.getDeclaredConstructor(
+                double.class,
+                org.patryk3211.powergrid.electricity.wire.IWireEndpoint.class,
+                org.patryk3211.powergrid.electricity.wire.IWireEndpoint.class,
+                OwnedFloatingNode.class,
+                OwnedFloatingNode.class,
+                WorldNetworks.class
+        ));
+        Assertions.assertNotNull(TransmissionLine.class.getDeclaredMethod("refreshDetachedEndpointNodes"));
+        Assertions.assertNotNull(WorldNetworks.class.getDeclaredMethod(
+                "addPreparedTransmissionLine",
+                org.patryk3211.powergrid.electricity.sim.ElectricalNetwork.class,
+                TransmissionLine.class
+        ));
+    }
+
+    @Test
+    void loadedEndpointNodeSupersedesItsPersistedPlaceholder() {
+        var endpoint = new ImaginaryWireEndpoint(Vec3.ZERO);
+        var placeholder = new OwnedFloatingNode(endpoint);
+        var loadedNode = new OwnedFloatingNode(endpoint);
+
+        var selected = WorldNetworks.selectLoadedOrIndexedNode(endpoint, placeholder, loadedNode);
+        Assertions.assertSame(loadedNode, selected);
+    }
+
+    @Test
+    void proxyEndpointCanResolveToANodeWithADifferentCanonicalEndpoint() {
+        var endpoint = new ImaginaryWireEndpoint(Vec3.ZERO);
+        var canonicalEndpoint = new ImaginaryWireEndpoint(new Vec3(1, 2, 3));
+        var proxyNode = new OwnedFloatingNode(canonicalEndpoint);
+
+        Assertions.assertSame(
+                proxyNode,
+                WorldNetworks.selectLoadedOrIndexedNode(endpoint, null, proxyNode)
+        );
+        Assertions.assertSame(
+                proxyNode,
+                WorldNetworks.selectLoadedOrIndexedNode(endpoint, proxyNode, null)
+        );
+    }
+
+    @Test
+    void transmissionTreeTraversalSelectsTheSegmentSideByCanonicalNodeIdentity() {
+        var physicalAlias = new ImaginaryWireEndpoint(Vec3.ZERO);
+        var canonicalEndpoint = new ImaginaryWireEndpoint(new Vec3(1, 2, 3));
+        var otherEndpoint = new ImaginaryWireEndpoint(new Vec3(4, 5, 6));
+        var canonicalNode = new OwnedFloatingNode(canonicalEndpoint);
+        var otherNode = new OwnedFloatingNode(otherEndpoint);
+
+        Assertions.assertNotEquals(physicalAlias, canonicalNode.endpoint);
+        Assertions.assertEquals(
+                WorldNetworks.TransmissionPartSide.FIRST,
+                WorldNetworks.transmissionPartSide(
+                        canonicalNode,
+                        otherNode,
+                        canonicalNode
+                )
+        );
+        Assertions.assertEquals(
+                WorldNetworks.TransmissionPartSide.SECOND,
+                WorldNetworks.transmissionPartSide(
+                        canonicalNode,
+                        otherNode,
+                        otherNode
+                )
+        );
+        Assertions.assertEquals(
+                WorldNetworks.TransmissionPartSide.NONE,
+                WorldNetworks.transmissionPartSide(
+                        canonicalNode,
+                        otherNode,
+                        new OwnedFloatingNode(physicalAlias)
+                )
+        );
+    }
+
+    @Test
+    void missingEndpointIndexCreatesTheCorrectPlaceholder() {
+        var endpoint = new ImaginaryWireEndpoint(Vec3.ZERO);
+
+        var placeholder = WorldNetworks.selectLoadedOrIndexedNode(endpoint, null, null);
+        Assertions.assertSame(endpoint, placeholder.endpoint);
+    }
+
+    @Test
+    void unloadedEndpointMovesAliasesAndPhysicalPartsToItsPlaceholder() {
+        var canonicalEndpoint = new ImaginaryWireEndpoint(Vec3.ZERO);
+        var physicalAlias = new ImaginaryWireEndpoint(new Vec3(1, 2, 3));
+        var unrelatedEndpoint = new ImaginaryWireEndpoint(new Vec3(4, 5, 6));
+        var loadedNode = new OwnedFloatingNode(canonicalEndpoint);
+        var placeholder = new OwnedFloatingNode(canonicalEndpoint);
+        var unrelatedNode = new OwnedFloatingNode(unrelatedEndpoint);
+        Map<org.patryk3211.powergrid.electricity.wire.IWireEndpoint, OwnedFloatingNode> endpointBindings =
+                new HashMap<>();
+        endpointBindings.put(canonicalEndpoint, loadedNode);
+        endpointBindings.put(physicalAlias, loadedNode);
+        endpointBindings.put(unrelatedEndpoint, unrelatedNode);
+        Map<OwnedFloatingNode, Set<String>> partIndex = new HashMap<>();
+        partIndex.put(loadedNode, new HashSet<>(Set.of("remote-segment")));
+        partIndex.put(placeholder, new HashSet<>(Set.of("existing-segment")));
+
+        WorldNetworks.rebindNodeAliasesByIdentity(endpointBindings, loadedNode, placeholder);
+        var movedParts = WorldNetworks.moveNodeIndex(partIndex, loadedNode, placeholder);
+
+        Assertions.assertSame(placeholder, endpointBindings.get(canonicalEndpoint));
+        Assertions.assertSame(placeholder, endpointBindings.get(physicalAlias));
+        Assertions.assertSame(unrelatedNode, endpointBindings.get(unrelatedEndpoint));
+        Assertions.assertFalse(partIndex.containsKey(loadedNode));
+        Assertions.assertEquals(
+                Set.of("remote-segment", "existing-segment"),
+                partIndex.get(placeholder)
+        );
+        Assertions.assertEquals(Set.of("remote-segment"), Set.copyOf(movedParts));
+    }
+
+    @Test
+    void replacingAnUnloadedEndpointKeepsItsDerivedWireConnected() {
+        var endpoint = new ImaginaryWireEndpoint(Vec3.ZERO);
+        var otherEndpoint = new ImaginaryWireEndpoint(new Vec3(1, 2, 3));
+        var loadedNode = new OwnedFloatingNode(endpoint);
+        var placeholder = new OwnedFloatingNode(endpoint);
+        var otherNode = new OwnedFloatingNode(otherEndpoint);
+        var network = new DummyElectricalNetwork(new NetworkGraph());
+        network.addNode(loadedNode);
+        network.addNode(otherNode);
+        var wire = new ElectricWire(1, loadedNode, otherNode);
+        network.addWire(wire);
+
+        network.addNode(placeholder);
+        wire.setNode1(placeholder);
+        network.removeNode(loadedNode);
+
+        Assertions.assertSame(network, wire.getNetwork());
+        Assertions.assertSame(placeholder, wire.getNode1());
+        Assertions.assertSame(otherNode, wire.getNode2());
+        Assertions.assertTrue(network.ownsNode(placeholder));
+        Assertions.assertFalse(network.ownsNode(loadedNode));
+    }
+
+    @Test
+    void exactPreparedNodeIsAddedWhenItsNetworkPointerIsStale() {
+        var endpoint = new ImaginaryWireEndpoint(Vec3.ZERO);
+        var node = new OwnedFloatingNode(endpoint);
+        var staleNetwork = new DummyElectricalNetwork(new NetworkGraph());
+        var targetNetwork = new DummyElectricalNetwork(new NetworkGraph());
+        node.setNetwork(staleNetwork);
+
+        WorldNetworks.addOrMergeExactNode(targetNetwork, node);
+
+        Assertions.assertSame(targetNetwork, node.getNetwork());
+        Assertions.assertTrue(targetNetwork.ownsNode(node));
+    }
+
+    @Test
+    void exactPreparedNodeMergesFromARealDifferentNetwork() {
+        var endpoint = new ImaginaryWireEndpoint(Vec3.ZERO);
+        var node = new OwnedFloatingNode(endpoint);
+        var originalNetwork = new DummyElectricalNetwork(new NetworkGraph());
+        var targetNetwork = new DummyElectricalNetwork(new NetworkGraph());
+        originalNetwork.addNode(node);
+
+        WorldNetworks.addOrMergeExactNode(targetNetwork, node);
+
+        Assertions.assertSame(targetNetwork, node.getNetwork());
+        Assertions.assertTrue(targetNetwork.ownsNode(node));
+        Assertions.assertFalse(originalNetwork.ownsNode(node));
+    }
+
+    @Test
+    void physicalOwnerEndpointPairsMatchInEitherDirectionOnly() {
+        var first = new BlockWireEndpoint(new BlockPos(1, 2, 3), 0);
+        var second = new BlockWireEndpoint(new BlockPos(4, 5, 6), 1);
+        var other = new BlockWireEndpoint(new BlockPos(7, 8, 9), 0);
+
+        Assertions.assertTrue(TransmissionLinePart.sameEndpoints(first, second, first, second));
+        Assertions.assertTrue(TransmissionLinePart.sameEndpoints(first, second, second, first));
+        Assertions.assertFalse(TransmissionLinePart.sameEndpoints(first, second, first, other));
+        Assertions.assertFalse(TransmissionLinePart.sameEndpoints(first, second, first, first));
+    }
+}

--- a/src/test/java/org/patryk3211/powergrid/electricity/TransmissionLineRecoveryTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/TransmissionLineRecoveryTests.java
@@ -29,6 +29,7 @@ import org.patryk3211.powergrid.electricity.wire.BaseWireEntity;
 import org.patryk3211.powergrid.electricity.wire.BlockWireEndpoint;
 import org.patryk3211.powergrid.electricity.wire.ImaginaryWireEndpoint;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -57,6 +58,48 @@ public class TransmissionLineRecoveryTests {
                 WorldNetworks.NodeBindingMode.BIND_AND_SPLIT,
                 true
         ));
+    }
+
+    @Test
+    void discoveryRequestedDuringDiscoveryIsDeferredInsteadOfDiscarded() {
+        var current = new HashSet<String>();
+        var deferred = new HashSet<String>();
+
+        WorldNetworks.enqueueIslandDiscovery("network", true, current, deferred);
+
+        Assertions.assertTrue(current.isEmpty());
+        Assertions.assertEquals(Set.of("network"), deferred);
+    }
+
+    @Test
+    void unresolvedIncrementalPartRemainsOwnedWhileRetryIsScheduled() {
+        var part = new Object();
+        var retries = new ArrayList<Object>();
+
+        var retained = WorldNetworks.retainRegisteredPartWhileResolving(
+                part,
+                false,
+                retries::add
+        );
+
+        Assertions.assertSame(part, retained);
+        Assertions.assertEquals(java.util.List.of(part), retries);
+        Assertions.assertEquals(3, WorldNetworks.MAX_INCREMENTAL_RESOLUTION_RETRIES);
+    }
+
+    @Test
+    void resolvedIncrementalPartDoesNotScheduleARetry() {
+        var part = new Object();
+        var retries = new ArrayList<Object>();
+
+        var retained = WorldNetworks.retainRegisteredPartWhileResolving(
+                part,
+                true,
+                retries::add
+        );
+
+        Assertions.assertSame(part, retained);
+        Assertions.assertTrue(retries.isEmpty());
     }
 
     @Test

--- a/src/test/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionConnectionEndpointsTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/sim/special/TransmissionConnectionEndpointsTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity.sim.special;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.patryk3211.powergrid.electricity.sim.node.OwnedFloatingNode;
+import org.patryk3211.powergrid.electricity.wire.BlockWireEndpoint;
+
+class TransmissionConnectionEndpointsTests {
+    @Test
+    void physicalProxyEndpointRemainsIndependentFromItsCanonicalNodeEndpoint() {
+        var physicalAlias = new BlockWireEndpoint(new BlockPos(438, 65, 54), 1);
+        var canonicalEndpoint = new BlockWireEndpoint(new BlockPos(438, 64, 54), 1);
+        var otherEndpoint = new BlockWireEndpoint(new BlockPos(438, 63, 62), 0);
+        var canonicalNode = new OwnedFloatingNode(canonicalEndpoint);
+        var endpoints = new TransmissionConnectionEndpoints(physicalAlias, otherEndpoint);
+
+        Assertions.assertNotEquals(canonicalNode.endpoint, endpoints.endpoint1());
+        Assertions.assertEquals(physicalAlias, endpoints.endpoint1());
+        Assertions.assertTrue(endpoints.matches(physicalAlias, otherEndpoint));
+        Assertions.assertFalse(endpoints.matches(canonicalEndpoint, otherEndpoint));
+    }
+
+    @Test
+    void physicalEndpointsRoundTripThroughTheExistingSavedDataKeys() {
+        var first = new BlockWireEndpoint(new BlockPos(-757, 65, 93), 2);
+        var second = new BlockWireEndpoint(new BlockPos(-757, 64, 90), 1);
+        var endpoints = new TransmissionConnectionEndpoints(first, second);
+        var tag = new CompoundTag();
+
+        endpoints.writeToNbt(tag);
+        var restored = TransmissionConnectionEndpoints.fromNbt(tag);
+
+        Assertions.assertEquals(first, restored.endpoint1());
+        Assertions.assertEquals(second, restored.endpoint2());
+        Assertions.assertTrue(tag.contains("Node1"));
+        Assertions.assertTrue(tag.contains("Node2"));
+        Assertions.assertEquals(2, tag.size());
+    }
+}

--- a/src/test/java/org/patryk3211/powergrid/electricity/wire/WireRenderSyncTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/wire/WireRenderSyncTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.electricity.wire;
+
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class WireRenderSyncTests {
+    @Test
+    void terminalGeometryContainsServerCalculatedEndpoints() {
+        var terminal1 = new Vec3(82.125, 68.75, 16.5);
+        var terminal2 = new Vec3(110.875, 71.25, 43.5);
+
+        var tag = WireRenderSync.terminalGeometry(terminal1, terminal2, true);
+        var positions = tag.getList("V", Tag.TAG_FLOAT);
+
+        Assertions.assertEquals(6, positions.size());
+        Assertions.assertEquals((float) terminal1.x, positions.getFloat(0));
+        Assertions.assertEquals((float) terminal1.y, positions.getFloat(1));
+        Assertions.assertEquals((float) terminal1.z, positions.getFloat(2));
+        Assertions.assertEquals((float) terminal2.x, positions.getFloat(3));
+        Assertions.assertEquals((float) terminal2.y, positions.getFloat(4));
+        Assertions.assertEquals((float) terminal2.z, positions.getFloat(5));
+        Assertions.assertTrue(tag.getBoolean("D"));
+        Assertions.assertFalse(tag.contains("Version"));
+    }
+}

--- a/src/test/java/org/patryk3211/powergrid/electricity/wire/WireRenderSyncTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/wire/WireRenderSyncTests.java
@@ -38,5 +38,6 @@ public class WireRenderSyncTests {
         Assertions.assertEquals((float) terminal2.z, positions.getFloat(5));
         Assertions.assertTrue(tag.getBoolean("D"));
         Assertions.assertFalse(tag.contains("Version"));
+        Assertions.assertFalse(tag.contains("Item"));
     }
 }

--- a/src/test/java/org/patryk3211/powergrid/electricity/wire/WireRenderSyncTests.java
+++ b/src/test/java/org/patryk3211/powergrid/electricity/wire/WireRenderSyncTests.java
@@ -20,6 +20,8 @@ import net.minecraft.world.phys.Vec3;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+
 public class WireRenderSyncTests {
     @Test
     void terminalGeometryContainsServerCalculatedEndpoints() {
@@ -39,5 +41,32 @@ public class WireRenderSyncTests {
         Assertions.assertTrue(tag.getBoolean("D"));
         Assertions.assertFalse(tag.contains("Version"));
         Assertions.assertFalse(tag.contains("Item"));
+    }
+
+    @Test
+    void terminalGeometryWaitsForWireMaterial() {
+        var tag = WireRenderSync.terminalGeometry(Vec3.ZERO, new Vec3(1, 2, 3), false);
+
+        Assertions.assertFalse(WireRenderSync.canApplyTerminalGeometry(tag, false));
+        Assertions.assertTrue(WireRenderSync.canApplyTerminalGeometry(tag, true));
+        Assertions.assertTrue(WireRenderSync.canApplyTerminalGeometry(new net.minecraft.nbt.CompoundTag(), false));
+    }
+
+    @Test
+    void renderBroadcastsOnlyReachCompletedTrackingSessions() {
+        var recipients = new WireTrackingRecipients<Object>();
+        var player = new Object();
+        var deliveries = new ArrayList<Object>();
+
+        recipients.forEach(deliveries::add);
+        Assertions.assertTrue(deliveries.isEmpty());
+
+        recipients.start(player);
+        recipients.forEach(deliveries::add);
+        Assertions.assertEquals(java.util.List.of(player), deliveries);
+
+        recipients.stop(player);
+        recipients.forEach(deliveries::add);
+        Assertions.assertEquals(java.util.List.of(player), deliveries);
     }
 }

--- a/src/test/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacketTests.java
+++ b/src/test/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacketTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.patryk3211.powergrid.network.packets;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.patryk3211.powergrid.electricity.wire.WireRenderSync;
+
+public class EntityDataS2CPacketTests {
+    @Test
+    void completePreSpawnDataReplacesStaleRenderOnlyData() {
+        int entityId = 42;
+        var renderOnly = WireRenderSync.terminalGeometry(Vec3.ZERO, new Vec3(1, 2, 3), false);
+
+        var complete = new CompoundTag();
+        complete.put("Item", new CompoundTag());
+
+        EntityDataS2CPacket.deferData(entityId, renderOnly);
+        EntityDataS2CPacket.deferData(entityId, complete);
+
+        var deferred = EntityDataS2CPacket.takeDeferredData(entityId);
+        Assertions.assertSame(complete, deferred);
+        Assertions.assertTrue(deferred.contains("Item"));
+        Assertions.assertFalse(deferred.contains("V"));
+        Assertions.assertNull(EntityDataS2CPacket.takeDeferredData(entityId));
+    }
+}

--- a/src/test/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacketTests.java
+++ b/src/test/java/org/patryk3211/powergrid/network/packets/EntityDataS2CPacketTests.java
@@ -17,11 +17,17 @@ package org.patryk3211.powergrid.network.packets;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.patryk3211.powergrid.electricity.wire.WireRenderSync;
 
 public class EntityDataS2CPacketTests {
+    @AfterEach
+    void clearDeferredData() {
+        EntityDataS2CPacket.clearDeferredData();
+    }
+
     @Test
     void completePreSpawnDataReplacesStaleRenderOnlyData() {
         int entityId = 42;
@@ -38,5 +44,21 @@ public class EntityDataS2CPacketTests {
         Assertions.assertTrue(deferred.contains("Item"));
         Assertions.assertFalse(deferred.contains("V"));
         Assertions.assertNull(EntityDataS2CPacket.takeDeferredData(entityId));
+    }
+
+    @Test
+    void staleRenderOnlyDataCannotReplaceCompletePreSpawnData() {
+        int entityId = 43;
+        var complete = new CompoundTag();
+        complete.put("Item", new CompoundTag());
+        var renderOnly = WireRenderSync.terminalGeometry(Vec3.ZERO, new Vec3(1, 2, 3), false);
+
+        EntityDataS2CPacket.deferData(entityId, complete);
+        EntityDataS2CPacket.deferData(entityId, renderOnly);
+
+        var deferred = EntityDataS2CPacket.takeDeferredData(entityId);
+        Assertions.assertSame(complete, deferred);
+        Assertions.assertTrue(deferred.contains("Item"));
+        Assertions.assertFalse(deferred.contains("V"));
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes long-distance transmission networks becoming incomplete after chunk unload/reload, adds a bounded verified rebuild for startup and manual recovery, and synchronizes authoritative wire render geometry when a client starts tracking a wire. It also prevents reconnect failures caused by stale render-only wire data being applied before the wire item is initialized.

The changes target the underlying lifecycle and identity problems rather than keeping the entire electrical network chunk-loaded.

Addresses the symptoms reported in #918 and the recurring transmission ownership/topology failures in #654 and #886.

## Root cause

Power Grid stores two related representations:

- persisted physical transmission parts owned by wire/cord entities;
- optimized logical transmission lines used by the electrical solver.

Several lifecycle paths allowed those representations to diverge:

1. When a terminal chunk unloaded, its real node could disappear while endpoint aliases and the node-to-part index still referenced the discarded object. A healthy optimized line could then be detached or only partially reconstructed when the chunk loaded again.
2. Rebuilding only optimized lines did not repair stale physical-part registrations, so an apparently successful rebuild could preserve invalid source data.
3. Multiblock/proxy endpoints may physically attach to a secondary block while resolving to a node canonically owned by a main block. Treating the physical endpoint and canonical node endpoint as the same identity caused false endpoint mismatches and repeated line replacement.
4. Topology reconstruction could admit a prepared line whose exact boundary nodes were not members of the selected solver network, producing `Prepared transmission line endpoints do not belong to the target network` and related split/re-entry failures.
5. Clients could receive a wire entity before their local endpoint block entities were ready. They reconstructed temporary terminal positions, produced an invalid curve, and removed only their local render entity even though the server-side wire and current remained valid.
6. The official client retains only the latest deferred entity-data packet for a numeric entity id. A geometry-only packet left behind by an earlier tracking or login session could therefore replace the complete wire-data packet. When that id was reused, `HangingWireEntity` tried to calculate render thickness before its `WireItemEntry` existed, causing a `wireThickness()` null-pointer exception and disconnecting the player while the spawn bundle was handled.

7. Live additions could register a physical transmission part while one or both endpoint nodes were still being initialized. The first logical-line creation then returned without attaching the part, the physical owner lost the reference, and there was no bounded retry. Internal block circuits could also finish connecting after the earlier transmission hooks, while island-discovery requests raised during an active discovery pass were discarded. The new cable or component therefore remained electrically detached until a full rebuild reconstructed the topology.
## Included changes

### Chunk unload/reload lifecycle

- Healthy derived transmission lines remain in the solver graph when a physical terminal unloads.
- The departing real node is atomically replaced with a passive placeholder.
- Every endpoint alias and persisted physical part indexed by the old node moves to the placeholder by node identity.
- Loading the terminal again migrates the same line and part index back to the real node without requiring a global rebuild.
- Unloading wire entities updates their persisted owner/chunk state without deleting the compact logical topology.
- Island discovery is scheduled after the node transition, while no terrain chunk is retained permanently.

### Physical endpoints versus canonical nodes

`TransmissionLinePart` now keeps its physical connection pair independently from its resolved electrical nodes.

- Physical endpoints are authoritative for owner validation, chunk planning and persistence.
- Canonical nodes are authoritative for topology traversal and solver connections.
- The existing `Node1` and `Node2` NBT fields remain in use, so no data-version or schema migration is introduced.
- Tree traversal selects the relevant segment side by canonical node identity.
- Ordinary endpoint binding no longer implicitly requests another line split. Callers that genuinely introduce a proxy alias request the split explicitly, preventing recursive `TransmissionLine.splitAt` calls.

### Solver-network invariants

- New and split lines refresh their detached endpoint nodes from the current endpoint index immediately before insertion.
- The exact boundary nodes are added or merged into the selected electrical network.
- Insertion is rejected if either exact node still does not belong to the target network.
- Segment removal determines first/last position by list index rather than stale node-object equality.

### Incremental additions and topology discovery

Newly placed cables and electrical components now join the live topology without requiring `/powergrid rebuild`:

- A physical wire owner retains its persisted `TransmissionLinePart` even when the first logical attachment must wait for endpoint initialization.
- Failed incremental attachments are retried at most 3 times, separated by 20 ticks.
- At most 16 incremental attachments are processed per server tick.
- Successful attachment schedules normal island discovery and current propagation.
- Completing a block entity's internal circuit explicitly schedules discovery for its final external-node networks.
- Discovery requested while another discovery pass is running is deferred to the next tick instead of being discarded.
- Starting a verified rebuild clears the incremental queue because the rebuild becomes the single topology authority for that interval.

The normal case still attaches immediately. The retry queue is populated only for a transiently unresolved part and does not scan the world or keep chunks loaded.
### Verified startup rebuild

Every server dimension schedules one verified rebuild from `WorldNetworks.preTick`, so it runs without a player login or player proximity requirement.

The rebuild is a bounded server-thread state machine:

1. Snapshot persisted physical-part registrations.
2. Build an atomic work unit from each part's owner chunk plus both endpoint chunks.
3. Refuse plans above 512 unique chunks.
4. Isolate the derived transmission topology, island discovery, solver ticks and state synchronization while physical entities continue normal server ticks.
5. Load at most 8 chunks at once with temporary entity-ticking tickets.
6. Wait until the complete batch is entity-ticking and its entities are loaded.
7. Refresh ready physical owners from their current endpoints.
8. Retain a matching saved registration when both physical terminal structures still exist but a late runtime electrical behaviour (for example a commutator) is not ready yet. Placeholder nodes carry it through final assembly.
9. Replace only an actually stale part; remove a missing-owner record only after its complete batch was verified.
10. Release the batch tickets before loading the next batch.
11. Recreate endpoint/node indexes and optimized logical lines once from the verified registrations, then resume solver work.
12. Observe unresolved late registrations for at most 100 post-isolation ticks. This settlement window performs no additional rebuild attempt and loads no chunks.

Temporary tickets are also released on failure, dimension unload and server shutdown, and have an expiry.

### Bounded retries

- Chunk batch load attempts: at most 3.
- Physical owner registration attempts: at most 3 total per batch.
- Final topology retries: at most 3 per unresolved part, separated by 20 ticks.
- Retry processing: at most 16 parts per server tick.
- Chunk attempt timeout: 100 ticks.
- Whole verified rebuild deadline: 5 minutes.

Each exhausted part logs its identifier, physical endpoints, resolved nodes, last known chunk, owner state and failure reason. Exhausting topology retries does not delete the persisted world record.

## `/powergrid rebuild`

The PR adds:

```text
/powergrid rebuild
```

Command behaviour:

- requires Minecraft permission level 2 (operator);
- affects only the command source's current dimension (normally the overworld from a dedicated-server console);
- starts the same asynchronous verified rebuild used during startup;
- allows only one rebuild per dimension at a time;
- has a 60-second per-dimension cooldown for accepted manual invocations;
- refuses a plan above the 512-chunk safety limit;
- reports the initial part/chunk/batch plan immediately;
- reports physical parts, refreshed/recovered/removed registrations, final line count and elapsed time on completion;
- reports partial/failure results and points the operator to the diagnostic log;
- does not break or replace placed blocks, scan every generated chunk, or keep network chunks loaded after the operation.

Existing `powergrid` debug, source, performance and configuration subcommands retain permission level 3.

## Wire visibility synchronization

When a player starts tracking a wire entity, the server now uses the exact tracking lifecycle rather than a broad tracking broadcast:

1. Minecraft sends the wire entity's spawn bundle.
2. `startSeenByPlayer` sends complete material and endpoint state directly to that exact player.
3. Hanging wires and cords then receive the existing-format packet containing the terminal geometry already calculated by the server.
4. Only players whose pairing has completed are admitted to later render-geometry broadcasts.
5. A player is removed from that recipient set before Minecraft queues the entity-removal packet.

This ordering fixes the reconnect and teleport crash seen in `HangingWireEntity.updateRenderParams`. A render-only packet contains terminal geometry but no wire item. If it arrived before entity spawn, the official client could defer it and consume it from the entity-join event, then call `WireItemEntry.wireThickness()` before the material was initialized. Restricting render-only delivery to completed tracking sessions prevents that invalid packet sequence for unmodified matching-version clients.

The universal source also hardens updated clients:

- complete deferred entity data cannot be replaced by a later render-only packet for the same numeric entity id;
- terminal geometry is ignored until the wire material is available;
- deferred entity data is cleared when the client leaves a world.

No packet type, packet registration, entity registry or wire-data schema changes. Dedicated-server clients of the matching mod version remain protocol-compatible and do not need this patch when the server runs the repaired build. The universal jar provides the additional client guards and runs the same server logic in integrated single-player.
## Performance and operational impact

- Incremental recovery runs only for a newly unresolved part, at most 16 attempts per tick, and performs no world scan or chunk loading.- During a verified scan, transmission is intentionally interrupted until one complete topology is available.
- At most 8 network chunks are held active at once.
- No permanent chunk ticket is created.
- Normal unload/reload does not consume rebuild retries or load chunks.
- Runtime memory retains the compact logical transmission topology and placeholder boundary nodes; it does not retain block entities, wire entities or terrain chunks. Memory therefore scales with persisted electrical-network size rather than loaded terrain.
- Startup duration grows with the number of discovered batches and is bounded by the limits above.

## Validation

Passed on this upstream `architectury-1.21.1/dev` port (Power Grid 0.5.6):

```text
./gradlew test --tests 'org.patryk3211.powergrid.*'
34/34 regression tests passed

./gradlew :forge:build
BUILD SUCCESSFUL
```

The regression suite covers batching, cooldown isolation, rebuild and incremental retry budgets, startup retention without runtime behaviour readiness, post-isolation settlement, physical/canonical endpoint separation, placeholder migration, solver-node membership, late internal-circuit discovery, deferred discovery, physical-owner retention during transient attachment, server-calculated render geometry, established tracking recipients, preservation of complete deferred wire data and rejection of geometry before material initialization.

The repository-wide `./gradlew test` task compiles successfully but currently reports 15 failures in legacy solver tests (`CapacitorTest`, `ElectronTubeTest`, `GraphedTest`, `SolverTests`, `StructureChangeTests`, `TransformerTests` and `TransmissionLineTest`). None of those test sources were modified; the new regression group passes independently. This is called out explicitly rather than hiding it with changes to existing solver tests.

Fabric is not enabled in this 1.21.1 branch (`include("fabric")` is commented in `settings.gradle`), so `:fabric:build` is not an available Gradle project here. The shared Fabric unload hook was updated consistently, while the available common and NeoForge compilation paths pass.

The underlying server fix series was exercised on Minecraft 1.21.1 / NeoForge 21.1.233 / Create 6.0.10 with a long-distance multiplayer network. A verified startup rebuild completed with 115 physical parts, 0 unresolved parts and 3 structurally retained late registrations; repeated long-distance teleport/unload/reload tests continued delivering power without another manual rebuild. The additional incremental-attachment and tracking-order changes were also ported to a 0.5.5.1 Fix 15 build, whose automated regression tests and NeoForge build pass; its in-world multiplayer verification remains an explicit deployment test rather than an unverified claim in this PR.
## Documentation

- `docs/operations/network-rebuild.md` describes the command, every rebuild phase, safety limits, failure interpretation and recovery boundary.
- `docs/operations/wire-visibility-sync.md` describes the render race and packet-compatible synchronization.
- `docs/decisions/0001-bounded-verified-transmission-rebuild.md` records the architectural decision, consequences, compatibility and rollback behaviour.
