### PR TITLE
Make wire tracking range configurable

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/config/CElectricity.java
+++ b/src/main/java/org/patryk3211/powergrid/config/CElectricity.java
@@ -21,6 +21,7 @@ public class CElectricity extends ConfigBase {
     public final ConfigBool explosiveDeconstruction = b(true, "explosiveDeconstruction", Comments.explosiveDeconstruction);
     public final ConfigBool overheating = b(true, "overheating", Comments.overheating);
     public final ConfigBool wireOverheating = b(true, "wireOverheating", Comments.wireOverheating);
+    public final ConfigInt wireTrackingRangeChunks =i(5, 1, 32, "wireTrackingRangeChunks", Comments.wireTrackingRangeChunks);
 
     public final ConfigFloat heaterFanProcessingSpeedMultiplier = f(0.75f, 0, "heaterFanProcessingSpeedMultiplier", Comments.heaterFanProcessingSpeedMultiplier);
 
@@ -86,6 +87,7 @@ public class CElectricity extends ConfigBase {
         public static final String explosiveDeconstruction = "Controls the behaviour of overheated devices. If false, instead of exploding, they break without dropping items.";
         public static final String overheating = "Controls the overheat mechanic. Devices which are overheated, break.";
         public static final String wireOverheating = "Controls the overheat mechanic for wires. Wires will burn if they overheat.";
+        public static final String wireTrackingRangeChunks = "Server tracking range for wire entities, in chunks. Higher values allow wires to remain visible farther away, but can increase server network traffic and client rendering load. This setting does not force-load chunks";
 
         public static final String heaterFanProcessingSpeedMultiplier = "Multiplier of the base fan bulk processing time applied to items processed with the heating coil (lower value means faster processing)";
 

--- a/src/main/java/org/patryk3211/powergrid/mixin/EntityTypeMixin.java
+++ b/src/main/java/org/patryk3211/powergrid/mixin/EntityTypeMixin.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 patryk3211
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.patryk3211.powergrid.mixin;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EntityType;
+import org.patryk3211.powergrid.PowerGrid;
+import org.patryk3211.powergrid.collections.ModdedConfigs;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Set;
+
+@Mixin(EntityType.class)
+public abstract class EntityTypeMixin {
+    @Unique
+    private static final Set<String> powergrid$WIRE_ENTITY_PATHS = Set.of(
+            "hanging_wire",
+            "block_wire",
+            "cord",
+            "string_light_cord");
+
+    @Inject(method = "clientTrackingRange()I", at = @At("RETURN"), cancellable = true)
+
+    private void powergrid$configureWireTrackingRange(CallbackInfoReturnable<Integer> cir) {
+        var serverConfig = ModdedConfigs.server();
+
+        if (serverConfig == null)
+            return;
+
+        EntityType<?> type = (EntityType<?>) (Object) this;
+        ResourceLocation typeId = EntityType.getKey(type);
+
+        if (typeId == null || !PowerGrid.MOD_ID.equals(typeId.getNamespace())
+                || !powergrid$WIRE_ENTITY_PATHS.contains(typeId.getPath()))
+            return;
+
+        cir.setReturnValue(serverConfig.electricity.wireTrackingRangeChunks.get());
+    }
+}

--- a/src/main/resources/powergrid.mixins.json
+++ b/src/main/resources/powergrid.mixins.json
@@ -10,6 +10,7 @@
     "BlockStateBaseMixin",
     "ChuteBlockEntityMixin",
     "EntityMixin",
+    "EntityTypeMixin",
     "FanProcessingMixin",
     "KineticBlockEntityAccessor",
     "LevelEntitiesAccessor",


### PR DESCRIPTION
## Changes
- adds a configurable wire tracking range;
- replaces the fixed tracking-range value with the configured value;
- preserves the existing default behavior when the configuration is not changed.