### PR TITLE
Add letter modifiers to circuit component String inputs

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/FloatProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/FloatProperty.java
@@ -43,13 +43,17 @@ public class FloatProperty extends ComponentProperty<Float> {
     public Float parse(String str) throws NumberFormatException {
         if(str == null || str.isEmpty()) throw new NumberFormatException("Value is empty");
         str = str.trim();
-        char modifierCharacter = Character.toLowerCase(str.charAt(str.length() - 1));
-        boolean hasModifier = modifierCharacter =='k' || modifierCharacter == 'm';
+        char modifierCharacter = str.charAt(str.length() - 1);
+        boolean hasModifier = "pnumkM".indexOf(modifierCharacter) != -1; 
         String numericPart = hasModifier ? str.substring(0, str.length() - 1) : str;
         var value = Float.parseFloat(numericPart);
         switch (modifierCharacter) {
-            case 'k' -> value *= 1_000f;
-            case 'm' -> value *= 1_000_000f;
+            case 'p' -> value /= 1_000_000_000_000f; // pico
+            case 'n' -> value /= 1_000_000_000f;     // nano
+            case 'u' -> value /= 1_000_000f;         // micro
+            case 'm' -> value /= 1_000f;             // milli
+            case 'k' -> value *= 1_000f;             // kilo
+            case 'M' -> value *= 1_000_000f;         // Mega
         }
         return limit(value);
     }

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/FloatProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/FloatProperty.java
@@ -41,7 +41,16 @@ public class FloatProperty extends ComponentProperty<Float> {
 
     @Override
     public Float parse(String str) throws NumberFormatException {
-        var value = Float.parseFloat(str);
+        if(str == null || str.isEmpty()) throw new NumberFormatException("Value is empty");
+        str = str.trim();
+        char modifierCharacter = Character.toLowerCase(str.charAt(str.length() - 1));
+        boolean hasModifier = modifierCharacter =='k' || modifierCharacter == 'm';
+        String numericPart = hasModifier ? str.substring(0, str.length() - 1) : str;
+        var value = Float.parseFloat(numericPart);
+        switch (modifierCharacter) {
+            case 'k' -> value *= 1_000f;
+            case 'm' -> value *= 1_000_000f;
+        }
         return limit(value);
     }
 


### PR DESCRIPTION
Adds ability to add k or m on the end of value to easily input 1k or 1m instead of counting zeros.
https://github.com/user-attachments/assets/0309981a-1691-49bb-afab-99abc99e90dc embed fail ):
(should be m mean milli and M mean mega? Someone frequently uses milliohms in powergrid?)