### PR TITLE
Fixed hanging wire rendering

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/electricity/wire/HangingWireRenderer.java
+++ b/src/main/java/org/patryk3211/powergrid/electricity/wire/HangingWireRenderer.java
@@ -246,8 +246,8 @@ public class HangingWireRenderer extends EntityRenderer<HangingWireEntity> {
                     thickness, thicknessOffset, thickness, thicknessOffset);
             quad(ms.last(), buffer, light, color,
                     x2 + cross1.x, y2 + cross1.y, z2 + cross1.z,
-                    x2 + cross2.x, y2 + cross2.y, z2 + cross2.z,
                     x2 - cross2.x, y2 - cross2.y, z2 - cross2.z,
+                    x2 + cross2.x, y2 + cross2.y, z2 + cross2.z,
                     x2 - cross1.x, y2 - cross1.y, z2 - cross1.z,
                     x2 - x1, y2 - y1, z2 - z1,
                     thickness, thicknessOffset, thickness, thicknessOffset);


### PR DESCRIPTION
One end-cap of the Hanging Wires was previously see-through. This usually isn't visible, since the default wires aren't thick enough for it to be noticeable

This happened because it was rendered facing the wrong way, causing it to be back-face culled.
Fixed by reversing the winding order.

Before:
<img width="2560" height="1440" alt="2026-08-20_18 14 01" src="https://github.com/user-attachments/assets/c06f8e0d-7a1b-44fd-8225-f0bcb3fdb225" />
After:
<img width="2560" height="1440" alt="2026-08-20_18 13 23" src="https://github.com/user-attachments/assets/48499921-1f00-4fee-b29d-42165a2566c9" />
