### PR TITLE
Added HolderLookup.Provider to PropertyEntry for NBT read/write

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/BakedCircuit.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/BakedCircuit.java
@@ -16,6 +16,7 @@
 package org.patryk3211.powergrid.circuits.circuitboard;
 
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -163,7 +164,7 @@ public class BakedCircuit {
         tag.put("Thermal", thermalTag);
     }
 
-    public void read(CompoundTag tag, boolean clientPacket) {
+    public void read(HolderLookup.Provider registries, CompoundTag tag, boolean clientPacket) {
         if(tag.contains("Thermal")) {
             var thermalTag = tag.getCompound("Thermal");
             for(var unit : thermalUnits) {
@@ -215,7 +216,7 @@ public class BakedCircuit {
                     var tagProperties = compound.getCompound("Properties");
                     for(var property : placed.component.getProperties()) {
                         var tagEntry = tagProperties.get(property.id().toString());
-                        var readValue = property.read(tagEntry);
+                        var readValue = property.read(registries, tagEntry);
                         if(tagEntry != null && !placed.get(property).equals(readValue)) {
                             // Value changed
                             placed.getEntry(property).setValueRaw(readValue);

--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlock.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlock.java
@@ -20,6 +20,8 @@ import dev.architectury.registry.menu.MenuRegistry;
 import net.createmod.catnip.math.VecHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponents;
@@ -105,8 +107,8 @@ public class CircuitBoardBlock extends ElectricBlock implements IBE<CircuitBoard
     @Override
     public void setPlacedBy(Level world, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
         withBlockEntityDo(world, pos, be -> {
-            be.setSchematic(CircuitSchematic.fromStack(stack));
-            be.setAdditionalData(stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag());
+            be.setSchematic(CircuitSchematic.fromStack(world.registryAccess(), stack));
+            be.setAdditionalData(world.registryAccess(), stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag());
         });
         super.setPlacedBy(world, pos, state, placer, stack);
     }
@@ -182,7 +184,7 @@ public class CircuitBoardBlock extends ElectricBlock implements IBE<CircuitBoard
         var stack = super.getCloneItemStack(level, pos, state);
         withBlockEntityDo(level, pos, be -> {
             var tag = new CompoundTag();
-            tag.put("Schematic", be.getSchematic().serializeNbt());
+            tag.put("Schematic", be.getSchematic().serializeNbt(level.registryAccess()));
             stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
         });
         return stack;
@@ -378,13 +380,16 @@ public class CircuitBoardBlock extends ElectricBlock implements IBE<CircuitBoard
 
     @Override
     public void appendHoverText(ItemStack stack, Item.TooltipContext context, List<Component> tooltipComponents, TooltipFlag tooltipFlag) {
-        var schematic = CircuitSchematic.fromStack(stack);
-        if(schematic != null && schematic.getName() != null) {
-            tooltipComponents.add(Lang
-                    .translate("circuit_board.tooltip.schematic")
-                    .add(Component.literal(schematic.getName()))
-                    .style(ChatFormatting.GRAY)
-                    .component());
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level != null) {
+            var schematic = CircuitSchematic.fromStack(level.registryAccess(), stack);
+            if(schematic != null && schematic.getName() != null) {
+                tooltipComponents.add(Lang
+                        .translate("circuit_board.tooltip.schematic")
+                        .add(Component.literal(schematic.getName()))
+                        .style(ChatFormatting.GRAY)
+                        .component());
+            }
         }
         super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
     }

--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
@@ -148,10 +148,10 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
         notifyUpdate();
     }
 
-    public void setAdditionalData(CompoundTag tag) {
+    public void setAdditionalData(HolderLookup.Provider registries, CompoundTag tag) {
         if(baked == null)
             return;
-        baked.read(tag, false);
+        baked.read(registries, tag, false);
         if(!level.isClientSide)
             notifyUpdate();
     }
@@ -362,7 +362,7 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
 
     @Override
     protected void write(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
-        tag.put("Schematic", schematic.serializeNbt());
+        tag.put("Schematic", schematic.serializeNbt(registries));
         if(baked != null)
             baked.write(tag);
         super.write(tag, registries, clientPacket);
@@ -371,7 +371,7 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
     @Override
     public void writeSafe(CompoundTag tag, HolderLookup.Provider registries) {
         super.writeSafe(tag, registries);
-        tag.put("Schematic", schematic.serializeSafeNbt());
+        tag.put("Schematic", schematic.serializeSafeNbt(registries));
     }
 
     @Override
@@ -383,11 +383,11 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
         }
         super.read(tag, registries, clientPacket);
         if(!clientPacket || tag.getBoolean("Rebuild") || baked == null) {
-            schematic.deserializeNbt(tag.getCompound("Schematic"));
+            schematic.deserializeNbt(registries, tag.getCompound("Schematic"));
             bakeCircuit();
         }
         if(baked != null)
-            baked.read(tag, clientPacket);
+            baked.read(registries, tag, clientPacket);
     }
 
     @Override
@@ -554,7 +554,7 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
     public ItemRequirement getRequiredItems(BlockState state) {
         var stack = ModdedBlocks.CIRCUIT_BOARD.asStack();
         var tag = new CompoundTag();
-        tag.put("Schematic", schematic.serializeSafeNbt());
+        tag.put("Schematic", schematic.serializeSafeNbt(level.registryAccess()));
         stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
         return new ItemRequirement(ItemRequirement.ItemUseType.CONSUME, stack);
     }

--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/IncompleteCircuitItem.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/IncompleteCircuitItem.java
@@ -17,6 +17,9 @@ package org.patryk3211.powergrid.circuits.circuitboard;
 
 import net.createmod.catnip.theme.Color;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -42,8 +45,8 @@ public class IncompleteCircuitItem extends Item {
         super(settings.stacksTo(1));
     }
 
-    private static CompoundTag makeAssemblyTag(CompoundTag schematicTag) {
-        var schematic = CircuitSchematic.fromNbt(schematicTag);
+    private static CompoundTag makeAssemblyTag(HolderLookup.Provider registries, CompoundTag schematicTag) {
+        var schematic = CircuitSchematic.fromNbt(registries, schematicTag);
         var componentAmounts = new HashMap<org.patryk3211.powergrid.circuits.components.Component, Integer>();
         int componentCount = 0;
         for(var placed : schematic.components()) {
@@ -87,7 +90,7 @@ public class IncompleteCircuitItem extends Item {
             return null;
         var tag = circuit.get(DataComponents.CUSTOM_DATA).copyTag();
         if(!tag.contains("Assembly")) {
-            tag.put("Assembly", makeAssemblyTag(tag.getCompound("Schematic")));
+            tag.put("Assembly", makeAssemblyTag(level.registryAccess(), tag.getCompound("Schematic")));
         }
         if(!insertComponent(level, tag.getCompound("Assembly"), component))
             return null;
@@ -133,7 +136,9 @@ public class IncompleteCircuitItem extends Item {
         if(!stack.get(DataComponents.CUSTOM_DATA).contains("Assembly")) {
             if(!stack.get(DataComponents.CUSTOM_DATA).contains("Schematic"))
                 return;
-            assemblyTag = makeAssemblyTag(stack.get(DataComponents.CUSTOM_DATA).copyTag().getCompound("Schematic"));
+            ClientLevel level = Minecraft.getInstance().level;
+            if (level == null) return;
+            assemblyTag = makeAssemblyTag(level.registryAccess(), stack.get(DataComponents.CUSTOM_DATA).copyTag().getCompound("Schematic"));
         } else {
             assemblyTag = stack.get(DataComponents.CUSTOM_DATA).copyTag().getCompound("Assembly");
         }

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/BooleanProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/BooleanProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
@@ -35,7 +36,7 @@ public class BooleanProperty extends ComponentProperty<Boolean> {
     }
 
     @Override
-    public Boolean read(@Nullable Tag element) {
+    public Boolean read(HolderLookup.Provider registries, @Nullable Tag element) {
         if(element == null)
             return false;
         if(element.getId() != Tag.TAG_BYTE)
@@ -44,7 +45,7 @@ public class BooleanProperty extends ComponentProperty<Boolean> {
     }
 
     @Override
-    public Tag write(Boolean value) {
+    public Tag write(HolderLookup.Provider registries, Boolean value) {
         return ByteTag.valueOf(value);
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/CalculatedProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/CalculatedProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
 import org.patryk3211.powergrid.circuits.schematic.PlacedComponent;
@@ -42,12 +43,12 @@ public class CalculatedProperty<T> extends ComponentProperty<T> {
     }
 
     @Override
-    public T read(@Nullable Tag element) {
+    public T read(HolderLookup.Provider registries, @Nullable Tag element) {
         return null;
     }
 
     @Override
-    public Tag write(T value) {
+    public Tag write(HolderLookup.Provider registries, T value) {
         return null;
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/ComponentProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/ComponentProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
@@ -65,8 +66,8 @@ public abstract class ComponentProperty<T> {
     public abstract T parse(String value) throws RuntimeException;
     public abstract String toString(T value);
 
-    public abstract T read(@Nullable Tag element);
-    public abstract Tag write(T value);
+    public abstract T read(HolderLookup.Provider registries, @Nullable Tag element);
+    public abstract Tag write(HolderLookup.Provider registries, T value);
 
     public abstract T defaultValue();
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/ConstantProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/ConstantProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
@@ -41,12 +42,12 @@ public class ConstantProperty extends ComponentProperty<String> {
     }
 
     @Override
-    public String read(@Nullable Tag element) {
+    public String read(HolderLookup.Provider registries, @Nullable Tag element) {
         return this.value.getString();
     }
 
     @Override
-    public Tag write(String value) {
+    public Tag write(HolderLookup.Provider registries, String value) {
         return null;
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/EnumProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/EnumProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
@@ -68,7 +69,7 @@ public class EnumProperty<T extends Enum<T>> extends ComponentProperty<T> {
     }
 
     @Override
-    public T read(@Nullable Tag element) {
+    public T read(HolderLookup.Provider registries, @Nullable Tag element) {
         if(element == null)
             return defaultValue;
         if(element.getId() != Tag.TAG_INT)
@@ -78,7 +79,7 @@ public class EnumProperty<T extends Enum<T>> extends ComponentProperty<T> {
     }
 
     @Override
-    public Tag write(T value) {
+    public Tag write(HolderLookup.Provider registries, T value) {
         return IntTag.valueOf(value.ordinal());
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/FloatProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/FloatProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.FloatTag;
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
@@ -88,7 +89,7 @@ public class FloatProperty extends ComponentProperty<Float> {
     }
 
     @Override
-    public Float read(@Nullable Tag element) {
+    public Float read(HolderLookup.Provider registries, @Nullable Tag element) {
         if(element == null)
             return defaultValue;
         if(element.getId() != Tag.TAG_FLOAT)
@@ -98,7 +99,7 @@ public class FloatProperty extends ComponentProperty<Float> {
     }
 
     @Override
-    public Tag write(Float value) {
+    public Tag write(HolderLookup.Provider registries, Float value) {
         return FloatTag.valueOf(value);
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/IntProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/IntProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
@@ -51,7 +52,7 @@ public class IntProperty extends ComponentProperty<Integer> {
     }
 
     @Override
-    public Integer read(@Nullable Tag element) {
+    public Integer read(HolderLookup.Provider registries, @Nullable Tag element) {
         if(element == null)
             return defaultValue;
         if(element.getId() != Tag.TAG_INT)
@@ -61,7 +62,7 @@ public class IntProperty extends ComponentProperty<Integer> {
     }
 
     @Override
-    public Tag write(Integer value) {
+    public Tag write(HolderLookup.Provider registries, Integer value) {
         return IntTag.valueOf(value);
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/PropertyEntry.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/PropertyEntry.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import org.patryk3211.powergrid.circuits.schematic.PlacedComponent;
 
@@ -37,19 +38,19 @@ public class PropertyEntry<T> {
         }
     }
 
-    public void read(CompoundTag compound) {
+    public void read(HolderLookup.Provider registries, CompoundTag compound) {
         if(property instanceof CalculatedProperty<T>)
             return;
         var element = compound.get(property.id().toString());
         if(element == null) {
             value = property.defaultValue();
         } else {
-            value = property.read(element);
+            value = property.read(registries, element);
         }
     }
 
-    public void write(CompoundTag compound) {
-        var element = property.write(value);
+    public void write(HolderLookup.Provider registries, CompoundTag compound) {
+        var element = property.write(registries, value);
         if(element == null)
             return;
         compound.put(property.id().toString(), element);
@@ -88,9 +89,9 @@ public class PropertyEntry<T> {
         }
 
         @Override
-        public void read(CompoundTag compound) { }
+        public void read(HolderLookup.Provider provider, CompoundTag compound) { }
         @Override
-        public void write(CompoundTag compound) { }
+        public void write(HolderLookup.Provider provider, CompoundTag compound) { }
 
         @Override
         public void setValue(String value) {

--- a/src/main/java/org/patryk3211/powergrid/circuits/components/properties/StringProperty.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/components/properties/StringProperty.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.components.properties;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
@@ -48,7 +49,7 @@ public class StringProperty extends ComponentProperty<String> {
     }
 
     @Override
-    public String read(@Nullable Tag element) {
+    public String read(HolderLookup.Provider registries, @Nullable Tag element) {
         if(element == null)
             return defaultValue;
         if(element.getId() != Tag.TAG_STRING)
@@ -58,7 +59,7 @@ public class StringProperty extends ComponentProperty<String> {
     }
 
     @Override
-    public Tag write(String value) {
+    public Tag write(HolderLookup.Provider registries, String value) {
         return StringTag.valueOf(value);
     }
 

--- a/src/main/java/org/patryk3211/powergrid/circuits/editor/CircuitDesignTableBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/editor/CircuitDesignTableBlockEntity.java
@@ -86,13 +86,13 @@ public class CircuitDesignTableBlockEntity extends ElectricBlockEntity implement
     @Override
     protected void write(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.write(tag, registries, clientPacket);
-        tag.put("Schematic", schematic.serializeNbt());
+        tag.put("Schematic", schematic.serializeNbt(level.registryAccess()));
     }
 
     @Override
     protected void read(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.read(tag, registries, clientPacket);
-        schematic.deserializeNbt(tag.getCompound("Schematic"));
+        schematic.deserializeNbt(level.registryAccess(), tag.getCompound("Schematic"));
         if(clientPacket)
             schematicChanged = true;
     }
@@ -114,7 +114,7 @@ public class CircuitDesignTableBlockEntity extends ElectricBlockEntity implement
                 return;
             stack.shrink(1);
         }
-        var result = schematic.toItemStack();
+        var result = schematic.toItemStack(level.registryAccess());
         inventory.setItem(2, result);
         schematic.clear();
         notifyUpdate();
@@ -130,7 +130,7 @@ public class CircuitDesignTableBlockEntity extends ElectricBlockEntity implement
             inventory.setItem(1, stack);
         }
         try {
-            schematic.deserializeNbt(stack.get(DataComponents.CUSTOM_DATA).copyTag().getCompound("Schematic"));
+            schematic.deserializeNbt(level.registryAccess(), stack.get(DataComponents.CUSTOM_DATA).copyTag().getCompound("Schematic"));
         } catch(RuntimeException e) {
             PowerGrid.LOGGER.error("Failed to load schematic from item: ", e);
         }

--- a/src/main/java/org/patryk3211/powergrid/circuits/editor/CircuitDesignTableLoadScreen.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/editor/CircuitDesignTableLoadScreen.java
@@ -24,6 +24,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.client.sounds.SoundManager;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.network.chat.Component;
@@ -103,7 +104,8 @@ public class CircuitDesignTableLoadScreen extends AbstractSimiContainerScreen<Ci
             }
             Files.deleteIfExists(file);
             try (OutputStream out = Files.newOutputStream(file, StandardOpenOption.CREATE)) {
-                NbtIo.writeCompressed(this.menu.contentHolder.schematic.serializeNbt(), out);
+                RegistryAccess registries = Minecraft.getInstance().level.registryAccess();
+                NbtIo.writeCompressed(this.menu.contentHolder.schematic.serializeNbt(registries), out);
             }
             back();
         } catch (IOException e) {
@@ -125,7 +127,8 @@ public class CircuitDesignTableLoadScreen extends AbstractSimiContainerScreen<Ci
             }
             try (InputStream in = Files.newInputStream(file, StandardOpenOption.READ)) {
                 var nbt = NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
-                var schematic = CircuitSchematic.fromNbt(nbt);
+                RegistryAccess registries = Minecraft.getInstance().level.registryAccess();
+                var schematic = CircuitSchematic.fromNbt(registries, nbt);
                 var name = fileNameInput.getValue();
                 if(name.endsWith(".nbt")) {
                     name = name.substring(0, name.length() - 4);

--- a/src/main/java/org/patryk3211/powergrid/circuits/schematic/CircuitSchematic.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/schematic/CircuitSchematic.java
@@ -15,6 +15,7 @@
  */
 package org.patryk3211.powergrid.circuits.schematic;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -70,21 +71,21 @@ public class CircuitSchematic {
         this.name = name;
     }
 
-    public static CircuitSchematic fromNbt(CompoundTag nbt) {
+    public static CircuitSchematic fromNbt(HolderLookup.Provider provider, CompoundTag nbt) {
         if(nbt == null)
             return null;
         var schematic = new CircuitSchematic();
-        schematic.deserializeNbt(nbt);
+        schematic.deserializeNbt(provider, nbt);
         return schematic;
     }
 
-    public static CircuitSchematic fromStack(ItemStack stack) {
+    public static CircuitSchematic fromStack(HolderLookup.Provider provider, ItemStack stack) {
         if(stack.isEmpty() || !stack.has(DataComponents.CUSTOM_DATA))
             return null;
-        return fromNbt(stack.get(DataComponents.CUSTOM_DATA).copyTag().getCompound("Schematic"));
+        return fromNbt(provider, stack.get(DataComponents.CUSTOM_DATA).copyTag().getCompound("Schematic"));
     }
 
-    public CompoundTag serializeNbt() {
+    public CompoundTag serializeNbt(HolderLookup.Provider provider) {
         var tag = new CompoundTag();
         tag.put("Front", front.serializeNbt());
         tag.put("Back", back.serializeNbt());
@@ -93,7 +94,7 @@ public class CircuitSchematic {
 
         var list = new ListTag();
         for(var component : components) {
-            list.add(component.serializeNbt());
+            list.add(component.serializeNbt(provider));
         }
         tag.put("Components", list);
         if(name != null) {
@@ -102,7 +103,7 @@ public class CircuitSchematic {
         return tag;
     }
 
-    public CompoundTag serializeSafeNbt() {
+    public CompoundTag serializeSafeNbt(HolderLookup.Provider provider) {
         var tag = new CompoundTag();
         tag.put("Front", front.serializeNbt());
         tag.put("Back", back.serializeNbt());
@@ -111,7 +112,7 @@ public class CircuitSchematic {
 
         var list = new ListTag();
         for(var component : components) {
-            list.add(component.serializeSafeNbt());
+            list.add(component.serializeSafeNbt(provider));
         }
         tag.put("Components", list);
         if(name != null) {
@@ -120,7 +121,7 @@ public class CircuitSchematic {
         return tag;
     }
 
-    public void deserializeNbt(CompoundTag tag) {
+    public void deserializeNbt(HolderLookup.Provider provider, CompoundTag tag) {
         try {
             // Default to legacy full pixel traces
             boolean fullPixelTraces = true;
@@ -143,7 +144,7 @@ public class CircuitSchematic {
             var list = tag.getList("Components", Tag.TAG_COMPOUND);
             for (var element : list) {
                 try {
-                    components.add(new PlacedComponent((CompoundTag) element, version));
+                    components.add(new PlacedComponent(provider, (CompoundTag) element, version));
                 } catch (RuntimeException e) {
                     PowerGrid.LOGGER.error("Failed to deserialize circuit component NBT", e);
                 }
@@ -227,10 +228,10 @@ public class CircuitSchematic {
         return components;
     }
 
-    public ItemStack toItemStack() {
+    public ItemStack toItemStack(HolderLookup.Provider provider) {
         var stack = ModdedItems.CIRCUIT_SCHEMATIC.asStack();
         var tag = new CompoundTag();
-        tag.put("Schematic", serializeSafeNbt());
+        tag.put("Schematic", serializeSafeNbt(provider));
         stack.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
         if(name != null)
             stack.set(DataComponents.CUSTOM_NAME, Component.literal(name));

--- a/src/main/java/org/patryk3211/powergrid/circuits/schematic/PlacedComponent.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/schematic/PlacedComponent.java
@@ -18,6 +18,7 @@ package org.patryk3211.powergrid.circuits.schematic;
 import net.createmod.catnip.math.VecHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
@@ -61,13 +62,13 @@ public class PlacedComponent {
     public Object customData;
     public boolean destroyed;
 
-    public PlacedComponent(CompoundTag tag, int version) {
+    public PlacedComponent(HolderLookup.Provider provider, CompoundTag tag, int version) {
         this(get(tag.getString("Id")), tag.getInt("X"), tag.getInt("Y"), tag.contains("UUID") ? tag.getUUID("UUID") : null);
         if(CircuitSchematic.VERSION != version)
             component.dataFixup(tag, version);
         var propertyMap = tag.getCompound("Properties");
         for(var entry : properties) {
-            entry.read(propertyMap);
+            entry.read(provider, propertyMap);
         }
     }
 
@@ -129,7 +130,7 @@ public class PlacedComponent {
             callback.get().accept(world);
     }
 
-    public CompoundTag serializeNbt() {
+    public CompoundTag serializeNbt(HolderLookup.Provider provider) {
         var tag = new CompoundTag();
 
         var id = ComponentRegistry.getId(component);
@@ -141,7 +142,7 @@ public class PlacedComponent {
         if(!properties.isEmpty()) {
             var propertyMap = new CompoundTag();
             for(var entry : properties) {
-                entry.write(propertyMap);
+                entry.write(provider, propertyMap);
             }
             tag.put("Properties", propertyMap);
         }
@@ -149,7 +150,7 @@ public class PlacedComponent {
         return tag;
     }
 
-    public Tag serializeSafeNbt() {
+    public Tag serializeSafeNbt(HolderLookup.Provider provider) {
         var tag = new CompoundTag();
 
         var id = ComponentRegistry.getId(component);
@@ -162,7 +163,7 @@ public class PlacedComponent {
             for(var entry : properties) {
                 if(entry.property.isUnsafe())
                     continue;
-                entry.write(propertyMap);
+                entry.write(provider, propertyMap);
             }
             tag.put("Properties", propertyMap);
         }

--- a/src/main/java/org/patryk3211/powergrid/network/packets/SaveSchematicC2SPacket.java
+++ b/src/main/java/org/patryk3211/powergrid/network/packets/SaveSchematicC2SPacket.java
@@ -41,7 +41,7 @@ public class SaveSchematicC2SPacket implements C2SPacket {
 
     public <T extends BlockEntity&ISchematicHolder> SaveSchematicC2SPacket(T be, @Nullable String name, CircuitSchematic schematic) {
         pos = be.getBlockPos();
-        nbt = schematic.serializeNbt();
+        nbt = schematic.serializeNbt(be.getLevel().registryAccess());
         this.name = name;
     }
 
@@ -77,7 +77,7 @@ public class SaveSchematicC2SPacket implements C2SPacket {
         var be = player.serverLevel().getBlockEntity(pos);
         if(be instanceof CircuitDesignTableBlockEntity table) {
             if(nbt != null) {
-                table.getSchematic().deserializeNbt(nbt);
+                table.getSchematic().deserializeNbt(player.serverLevel().registryAccess(), nbt);
                 table.setSchematicName(name);
                 table.notifyUpdate();
 
@@ -94,7 +94,7 @@ public class SaveSchematicC2SPacket implements C2SPacket {
             }
         } else if(be instanceof ISchematicHolder holder) {
             if(player.isCreative() && nbt != null) {
-                holder.setSchematic(CircuitSchematic.fromNbt(nbt));
+                holder.setSchematic(CircuitSchematic.fromNbt(player.serverLevel().registryAccess(), nbt));
             }
         }
     }

--- a/src/main/java/org/patryk3211/powergrid/network/packets/UpdateComponentBiPacket.java
+++ b/src/main/java/org/patryk3211/powergrid/network/packets/UpdateComponentBiPacket.java
@@ -44,7 +44,7 @@ public class UpdateComponentBiPacket implements S2CPacket, C2SPacket {
         assert componentId >= 0;
         propertyId = property.id();
         propertyValue = new CompoundTag();
-        component.getEntry(property).write(propertyValue);
+        component.getEntry(property).write(be.getLevel().registryAccess(), propertyValue);
     }
 
     public UpdateComponentBiPacket(CircuitBoardBlockEntity be, PlacedComponent component, ResourceLocation propertyId) {
@@ -53,7 +53,7 @@ public class UpdateComponentBiPacket implements S2CPacket, C2SPacket {
         assert componentId >= 0;
         this.propertyId = propertyId;
         propertyValue = new CompoundTag();
-        component.getEntry(propertyId).write(propertyValue);
+        component.getEntry(propertyId).write(be.getLevel().registryAccess(), propertyValue);
     }
 
     public UpdateComponentBiPacket(FriendlyByteBuf buf) {
@@ -76,7 +76,7 @@ public class UpdateComponentBiPacket implements S2CPacket, C2SPacket {
         be.ifPresent(circuit -> {
             var placed = circuit.getSchematic().components().get(componentId);
             var entry = placed.getEntry(propertyId);
-            entry.read(propertyValue);
+            entry.read(world.registryAccess(), propertyValue);
             placed.stateUpdated();
             if(!world.isClientSide) {
                 // Server must broadcast this update to all clients


### PR DESCRIPTION
A very simple addition that adds a `RegistryAccess`/`HolderLookup.Provider` parameter to the Tag reading and writing for the `PropertyEntry` class.

I created an `ItemStack` property in an addon Im working on.  Parsing and converting this type from tags requires this provider parameter.  Working this value into the call seems like the best solution, and adds a slight bit more flexibility for future properties.  I feel there could be other ways to fetch this property, but not nearly as clean.  Resolving this with mixins requires quite a lot of code thats all scattered about.  And probably would break on PG updates or refactors.

Ive compiled and tested successfully, seems loading, unloading, crafting etc all seem to be unchanged.

Would be very helpful for me and my addon if it had this, makes things much easier.  I wrote this staying up way to late, hopefully its comprehensible!
