### PR TITLE
Fix/tfmg ce getpos compat

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 //    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-forge:$rei_version"
 
     // Create: The Factory Must Grow
-    modCompileOnly "curse.maven:tfmg-community-edition-1653026:8665896"
+    modCompileOnly "curse.maven:tfmg-community-edition-1653026:8723583"
 
     // TIS-3D
     modCompileOnly("maven.modrinth:tis3d-renewed:${tis3d_version}")

--- a/forge/src/main/java/org/patryk3211/powergrid/compat/tfmg/TFMGCompatDeviceConnectorBlockEntity.java
+++ b/forge/src/main/java/org/patryk3211/powergrid/compat/tfmg/TFMGCompatDeviceConnectorBlockEntity.java
@@ -30,7 +30,7 @@ import org.patryk3211.powergrid.electricity.deviceconnector.DeviceConnectorBlock
 import org.patryk3211.powergrid.electricity.deviceconnector.DeviceConnectorBlockEntity;
 
 public class TFMGCompatDeviceConnectorBlockEntity extends DeviceConnectorBlockEntity implements IElectric {
-    public ElectricBlockValues data = new ElectricBlockValues(getPos());
+    public ElectricBlockValues data = new ElectricBlockValues(getBlockPos());
     private int voltage;
     private boolean powerRefresh = false;
     private boolean firstUpdate = false;
@@ -82,8 +82,8 @@ public class TFMGCompatDeviceConnectorBlockEntity extends DeviceConnectorBlockEn
     }
 
     @Override
-    public BlockPos getPos() {
-        return getBlockPos();
+    public long getPos() {
+        return getBlockPos().asLong();
     }
 
     @Override


### PR DESCRIPTION
Fixes #1068

TFMG CE 1.2.4b changed `IElectric#getPos()` from returning `BlockPos` to returning a packed `long`.

Power Grid 0.6.1 was still compiled against TFMG CE 1.2.3a and implemented the old method signature. With TFMG CE 1.2.4b this caused an `AbstractMethodError` when a Power Grid Device Connector was placed and ticked.

This change:

- updates the compile-only TFMG CE dependency to 1.2.4b
- implements `long getPos()` using `getBlockPos().asLong()`
- uses `getBlockPos()` directly when constructing `ElectricBlockValues`

Tested with:

- Minecraft 1.21.1
- NeoForge 21.1.250
- Create 6.0.10
- Power Grid 0.6.1
- TFMG CE 1.2.4b

Verified that the Device Connector can be placed and ticked without crashing the client or server.