### PR TITLE
Some tiny modifications to CircuitBoardBlockEntity for fetching components.

### DIFF
--- a/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
+++ b/src/main/java/org/patryk3211/powergrid/circuits/circuitboard/CircuitBoardBlockEntity.java
@@ -63,6 +63,7 @@ import org.patryk3211.powergrid.utility.ClientSideAccess;
 import org.patryk3211.powergrid.utility.Lang;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import static org.patryk3211.powergrid.circuits.circuitboard.CircuitBoardBlock.HORIZONTAL_FACING;
 import static org.patryk3211.powergrid.circuits.circuitboard.CircuitBoardBlock.ROTATION;
@@ -441,6 +442,35 @@ public class CircuitBoardBlockEntity extends ElectricBlockEntity implements IEle
         componentCache.put(ofClass, components);
         return components;
     }
+
+    public Stream<PlacedComponent> getComponentsStream() {
+        return schematic.components().stream();
+    }
+
+    public <T> @Nullable PlacedComponent getComponent(Class<T> ofClass, int x, int y) {
+        Stream<PlacedComponent> searcher = componentCache.containsKey(ofClass) ?
+            componentCache.get(ofClass).stream() : schematic.components().stream();
+        for (var iter = searcher.iterator(); iter.hasNext();) {
+            PlacedComponent placed = iter.next();
+            if (placed.x != x && placed.y != y) continue;
+            if (!ofClass.isInstance(placed.component)) continue;
+            return placed;
+        }
+        return null;
+    }
+
+    public <T> @Nullable PlacedComponent getComponent(Class<T> ofClass, UUID uuid) {
+        Stream<PlacedComponent> searcher = componentCache.containsKey(ofClass) ?
+            componentCache.get(ofClass).stream() : schematic.components().stream();
+        for (var iter = searcher.iterator(); iter.hasNext();) {
+            PlacedComponent placed = iter.next();
+            if (!uuid.equals(placed.uuid)) continue;
+            if (!ofClass.isInstance(placed.component)) continue;
+            return placed;
+        }
+        return null;
+    }
+
 
     @Override
     public void invalidate() {


### PR DESCRIPTION
Pretty tiny modification.  Just adds a few helpers and fetchers for getting placed components on a board for external addons.

Found original one to be not very flexible.  These methods provide easy ways of fetching a specific component without having to create a new array of components that will just be discarded.

Mot much else to say really, pretty small!